### PR TITLE
Add the Go service foundation

### DIFF
--- a/cmd/error-tracer/main.go
+++ b/cmd/error-tracer/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/soulteary/Error-Tracer/internal/config"
+	appserver "github.com/soulteary/Error-Tracer/internal/server"
+)
+
+func main() {
+	cfg := config.FromEnvironment()
+	app := appserver.New()
+
+	httpServer := &http.Server{
+		Addr:              cfg.Address,
+		Handler:           app.Handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		<-ctx.Done()
+		app.SetReady(false)
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)
+		defer cancel()
+
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			slog.Error("graceful shutdown failed", "error", err)
+		}
+	}()
+
+	slog.Info("starting Error-Tracer", "address", cfg.Address)
+	if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		slog.Error("server stopped unexpectedly", "error", err)
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/soulteary/Error-Tracer
+
+go 1.27.0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	defaultAddress         = ":8080"
+	defaultShutdownTimeout = 10 * time.Second
+)
+
+// Config contains process-level settings for the Error-Tracer service.
+type Config struct {
+	Address         string
+	ShutdownTimeout time.Duration
+}
+
+// FromEnvironment loads configuration without mutating process state.
+func FromEnvironment() Config {
+	address := strings.TrimSpace(os.Getenv("ERROR_TRACER_ADDRESS"))
+	if address == "" {
+		address = defaultAddress
+	}
+
+	return Config{
+		Address:         address,
+		ShutdownTimeout: defaultShutdownTimeout,
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFromEnvironmentUsesDefaults(t *testing.T) {
+	t.Setenv("ERROR_TRACER_ADDRESS", "")
+
+	cfg := FromEnvironment()
+	if cfg.Address != ":8080" {
+		t.Fatalf("Address = %q, want %q", cfg.Address, ":8080")
+	}
+	if cfg.ShutdownTimeout != 10*time.Second {
+		t.Fatalf("ShutdownTimeout = %s, want %s", cfg.ShutdownTimeout, 10*time.Second)
+	}
+}
+
+func TestFromEnvironmentReadsAddress(t *testing.T) {
+	t.Setenv("ERROR_TRACER_ADDRESS", " 127.0.0.1:9090 ")
+
+	cfg := FromEnvironment()
+	if cfg.Address != "127.0.0.1:9090" {
+		t.Fatalf("Address = %q, want %q", cfg.Address, "127.0.0.1:9090")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"sync/atomic"
+)
+
+// Server owns the HTTP routes and service readiness state.
+type Server struct {
+	handler http.Handler
+	ready   atomic.Bool
+}
+
+// New creates a service with liveness and readiness endpoints.
+func New() *Server {
+	server := &Server{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", server.health)
+	mux.HandleFunc("GET /readyz", server.readiness)
+	server.handler = mux
+	server.ready.Store(true)
+	return server
+}
+
+// Handler returns the service HTTP handler.
+func (s *Server) Handler() http.Handler {
+	return s.handler
+}
+
+// SetReady updates whether the process can accept new work.
+func (s *Server) SetReady(ready bool) {
+	s.ready.Store(ready)
+}
+
+func (s *Server) health(w http.ResponseWriter, _ *http.Request) {
+	writeStatus(w, http.StatusOK, "ok")
+}
+
+func (s *Server) readiness(w http.ResponseWriter, _ *http.Request) {
+	if !s.ready.Load() {
+		writeStatus(w, http.StatusServiceUnavailable, "unavailable")
+		return
+	}
+	writeStatus(w, http.StatusOK, "ready")
+}
+
+func writeStatus(w http.ResponseWriter, statusCode int, status string) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(statusCode)
+	_, _ = io.WriteString(w, `{"status":"`+status+`"}`+"\n")
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealth(t *testing.T) {
+	app := New()
+	request := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	response := httptest.NewRecorder()
+
+	app.Handler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
+	}
+	if got := response.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want %q", got, "no-store")
+	}
+	if got := response.Body.String(); got != "{\"status\":\"ok\"}\n" {
+		t.Fatalf("body = %q, want health JSON", got)
+	}
+}
+
+func TestReadinessTracksState(t *testing.T) {
+	app := New()
+
+	assertStatus := func(want int) {
+		t.Helper()
+		request := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		response := httptest.NewRecorder()
+		app.Handler().ServeHTTP(response, request)
+		if response.Code != want {
+			t.Fatalf("status = %d, want %d", response.Code, want)
+		}
+	}
+
+	assertStatus(http.StatusOK)
+	app.SetReady(false)
+	assertStatus(http.StatusServiceUnavailable)
+}
+
+func TestHealthRejectsOtherMethods(t *testing.T) {
+	app := New()
+	request := httptest.NewRequest(http.MethodPost, "/healthz", nil)
+	response := httptest.NewRecorder()
+
+	app.Handler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusMethodNotAllowed)
+	}
+}


### PR DESCRIPTION
## Summary

- initialize the Go 1.27 module and `cmd/error-tracer` entry point
- add environment-based address configuration
- add bounded HTTP server timeouts and signal-aware graceful shutdown
- expose distinct `/healthz` and `/readyz` endpoints
- make readiness state concurrency-safe

## Scope

This is infrastructure only. It intentionally does not add event ingestion, persistence, authentication, or a dashboard; each will be reviewed in a separate PR.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`

## Dependencies

This PR adds only new Go files and can merge independently of #4 and #5. The legal cleanup PRs should still be merged first to keep project history clear.