### PR TITLE
Add concurrency-safe issue aggregation

### DIFF
--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -1,0 +1,151 @@
+package store
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/soulteary/Error-Tracer/internal/event"
+)
+
+// Memory is a concurrency-safe in-memory store for development and tests.
+type Memory struct {
+	mu     sync.RWMutex
+	issues map[string]Issue
+}
+
+// NewMemory creates an empty in-memory store.
+func NewMemory() *Memory {
+	return &Memory{issues: make(map[string]Issue)}
+}
+
+// Record adds an event to its fingerprint group.
+func (m *Memory) Record(ctx context.Context, projectID string, captured event.Event) (Issue, error) {
+	if err := ctx.Err(); err != nil {
+		return Issue{}, err
+	}
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return Issue{}, ErrProjectRequired
+	}
+	if captured.ReceivedAt.IsZero() {
+		return Issue{}, ErrReceivedAtEmpty
+	}
+
+	fingerprint := captured.Fingerprint()
+	key := issueKey(projectID, fingerprint)
+	captured = cloneEvent(captured)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	issue, exists := m.issues[key]
+	if !exists {
+		issue = Issue{
+			ProjectID:   projectID,
+			Fingerprint: fingerprint,
+			Kind:        captured.Kind,
+			Message:     captured.Message,
+			SourceURL:   captured.SourceURL,
+			Line:        captured.Line,
+			Column:      captured.Column,
+			Status:      IssueStatusOpen,
+			FirstSeen:   captured.ReceivedAt,
+			LastSeen:    captured.ReceivedAt,
+			LastEvent:   captured,
+		}
+	}
+
+	issue.Occurrences++
+	if captured.ReceivedAt.Before(issue.FirstSeen) {
+		issue.FirstSeen = captured.ReceivedAt
+	}
+	if !captured.ReceivedAt.Before(issue.LastSeen) {
+		issue.LastSeen = captured.ReceivedAt
+		issue.LastEvent = captured
+	}
+	m.issues[key] = issue
+	return cloneIssue(issue), nil
+}
+
+// GetIssue returns one issue from one project.
+func (m *Memory) GetIssue(ctx context.Context, projectID, fingerprint string) (Issue, error) {
+	if err := ctx.Err(); err != nil {
+		return Issue{}, err
+	}
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return Issue{}, ErrProjectRequired
+	}
+
+	m.mu.RLock()
+	issue, exists := m.issues[issueKey(projectID, fingerprint)]
+	m.mu.RUnlock()
+	if !exists {
+		return Issue{}, ErrIssueNotFound
+	}
+	return cloneIssue(issue), nil
+}
+
+// ListIssues returns issues ordered by most recently seen, then fingerprint.
+func (m *Memory) ListIssues(ctx context.Context, projectID string, options ListOptions) (IssuePage, error) {
+	if err := ctx.Err(); err != nil {
+		return IssuePage{}, err
+	}
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return IssuePage{}, ErrProjectRequired
+	}
+	options = normalizeListOptions(options)
+
+	m.mu.RLock()
+	issues := make([]Issue, 0, len(m.issues))
+	for _, issue := range m.issues {
+		if issue.ProjectID == projectID {
+			issues = append(issues, cloneIssue(issue))
+		}
+	}
+	m.mu.RUnlock()
+
+	sort.Slice(issues, func(i, j int) bool {
+		if issues[i].LastSeen.Equal(issues[j].LastSeen) {
+			return issues[i].Fingerprint < issues[j].Fingerprint
+		}
+		return issues[i].LastSeen.After(issues[j].LastSeen)
+	})
+
+	total := len(issues)
+	start := min(options.Offset, total)
+	end := min(start+options.Limit, total)
+	return IssuePage{
+		Issues: issues[start:end],
+		Total:  total,
+		Limit:  options.Limit,
+		Offset: options.Offset,
+	}, nil
+}
+
+func issueKey(projectID, fingerprint string) string {
+	return projectID + "\x00" + fingerprint
+}
+
+func cloneIssue(issue Issue) Issue {
+	issue.LastEvent = cloneEvent(issue.LastEvent)
+	return issue
+}
+
+func cloneEvent(captured event.Event) event.Event {
+	if captured.OccurredAt != nil {
+		occurredAt := *captured.OccurredAt
+		captured.OccurredAt = &occurredAt
+	}
+	if captured.Tags != nil {
+		tags := make(map[string]string, len(captured.Tags))
+		for key, value := range captured.Tags {
+			tags[key] = value
+		}
+		captured.Tags = tags
+	}
+	return captured
+}

--- a/internal/store/memory_test.go
+++ b/internal/store/memory_test.go
@@ -1,0 +1,168 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/soulteary/Error-Tracer/internal/event"
+)
+
+func TestMemoryRecordAggregatesMatchingEvents(t *testing.T) {
+	memory := NewMemory()
+	firstTime := time.Date(2026, time.August, 29, 1, 0, 0, 0, time.UTC)
+	secondTime := firstTime.Add(time.Minute)
+	first := testEvent(firstTime)
+	second := testEvent(secondTime)
+	second.Release = "2.0.0"
+
+	if _, err := memory.Record(context.Background(), "project-a", first); err != nil {
+		t.Fatalf("record first event: %v", err)
+	}
+	issue, err := memory.Record(context.Background(), "project-a", second)
+	if err != nil {
+		t.Fatalf("record second event: %v", err)
+	}
+
+	if issue.Occurrences != 2 {
+		t.Fatalf("Occurrences = %d, want 2", issue.Occurrences)
+	}
+	if !issue.FirstSeen.Equal(firstTime) {
+		t.Fatalf("FirstSeen = %s, want %s", issue.FirstSeen, firstTime)
+	}
+	if !issue.LastSeen.Equal(secondTime) {
+		t.Fatalf("LastSeen = %s, want %s", issue.LastSeen, secondTime)
+	}
+	if issue.LastEvent.Release != "2.0.0" {
+		t.Fatalf("LastEvent.Release = %q, want latest event", issue.LastEvent.Release)
+	}
+}
+
+func TestMemorySeparatesProjects(t *testing.T) {
+	memory := NewMemory()
+	captured := testEvent(time.Now())
+
+	for _, projectID := range []string{"project-a", "project-b"} {
+		if _, err := memory.Record(context.Background(), projectID, captured); err != nil {
+			t.Fatalf("record %s: %v", projectID, err)
+		}
+	}
+
+	for _, projectID := range []string{"project-a", "project-b"} {
+		page, err := memory.ListIssues(context.Background(), projectID, ListOptions{})
+		if err != nil {
+			t.Fatalf("list %s: %v", projectID, err)
+		}
+		if page.Total != 1 || page.Issues[0].ProjectID != projectID {
+			t.Fatalf("page for %s = %#v, want one isolated issue", projectID, page)
+		}
+	}
+}
+
+func TestMemoryListIssuesIsBoundedAndOrdered(t *testing.T) {
+	memory := NewMemory()
+	base := time.Date(2026, time.August, 29, 1, 0, 0, 0, time.UTC)
+	for index := 0; index < 3; index++ {
+		captured := testEvent(base.Add(time.Duration(index) * time.Minute))
+		captured.Message = fmt.Sprintf("failure-%d", index)
+		if _, err := memory.Record(context.Background(), "project-a", captured); err != nil {
+			t.Fatalf("record event %d: %v", index, err)
+		}
+	}
+
+	page, err := memory.ListIssues(context.Background(), "project-a", ListOptions{Limit: 1, Offset: 1})
+	if err != nil {
+		t.Fatalf("list issues: %v", err)
+	}
+	if page.Total != 3 || len(page.Issues) != 1 {
+		t.Fatalf("page = %#v, want one of three issues", page)
+	}
+	if page.Issues[0].Message != "failure-1" {
+		t.Fatalf("message = %q, want second-most-recent issue", page.Issues[0].Message)
+	}
+}
+
+func TestMemoryRecordIsConcurrencySafe(t *testing.T) {
+	memory := NewMemory()
+	captured := testEvent(time.Now())
+	const workers = 100
+
+	var waitGroup sync.WaitGroup
+	errorsChannel := make(chan error, workers)
+	for range workers {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			_, err := memory.Record(context.Background(), "project-a", captured)
+			errorsChannel <- err
+		}()
+	}
+	waitGroup.Wait()
+	close(errorsChannel)
+	for err := range errorsChannel {
+		if err != nil {
+			t.Fatalf("record event: %v", err)
+		}
+	}
+
+	issue, err := memory.GetIssue(context.Background(), "project-a", captured.Fingerprint())
+	if err != nil {
+		t.Fatalf("get issue: %v", err)
+	}
+	if issue.Occurrences != workers {
+		t.Fatalf("Occurrences = %d, want %d", issue.Occurrences, workers)
+	}
+}
+
+func TestMemoryReturnsDefensiveCopies(t *testing.T) {
+	memory := NewMemory()
+	captured := testEvent(time.Now())
+	captured.Tags = map[string]string{"feature": "checkout"}
+	issue, err := memory.Record(context.Background(), "project-a", captured)
+	if err != nil {
+		t.Fatalf("record event: %v", err)
+	}
+
+	issue.LastEvent.Tags["feature"] = "modified"
+	stored, err := memory.GetIssue(context.Background(), "project-a", captured.Fingerprint())
+	if err != nil {
+		t.Fatalf("get issue: %v", err)
+	}
+	if stored.LastEvent.Tags["feature"] != "checkout" {
+		t.Fatalf("stored tags were mutated through returned issue: %#v", stored.LastEvent.Tags)
+	}
+}
+
+func TestMemoryRejectsInvalidInputAndCancelledContext(t *testing.T) {
+	memory := NewMemory()
+	captured := testEvent(time.Now())
+
+	if _, err := memory.Record(context.Background(), "", captured); !errors.Is(err, ErrProjectRequired) {
+		t.Fatalf("empty project error = %v, want ErrProjectRequired", err)
+	}
+	captured.ReceivedAt = time.Time{}
+	if _, err := memory.Record(context.Background(), "project-a", captured); !errors.Is(err, ErrReceivedAtEmpty) {
+		t.Fatalf("empty received_at error = %v, want ErrReceivedAtEmpty", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := memory.ListIssues(ctx, "project-a", ListOptions{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled context error = %v, want context.Canceled", err)
+	}
+}
+
+func testEvent(receivedAt time.Time) event.Event {
+	return event.Event{
+		ID:         "event-id",
+		Kind:       event.KindError,
+		Message:    "boom",
+		SourceURL:  "https://example.com/app.js",
+		Line:       10,
+		Column:     2,
+		ReceivedAt: receivedAt,
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,0 +1,80 @@
+// Package store defines persistence contracts for captured events and issues.
+package store
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/soulteary/Error-Tracer/internal/event"
+)
+
+const (
+	defaultPageSize = 50
+	maxPageSize     = 100
+)
+
+var (
+	ErrIssueNotFound   = errors.New("issue not found")
+	ErrProjectRequired = errors.New("project ID is required")
+	ErrReceivedAtEmpty = errors.New("event received_at is required")
+)
+
+// IssueStatus describes the triage state of an aggregated issue.
+type IssueStatus string
+
+const (
+	IssueStatusOpen     IssueStatus = "open"
+	IssueStatusResolved IssueStatus = "resolved"
+	IssueStatusIgnored  IssueStatus = "ignored"
+)
+
+// Issue is the server-side aggregation of events with the same fingerprint.
+type Issue struct {
+	ProjectID   string      `json:"-"`
+	Fingerprint string      `json:"fingerprint"`
+	Kind        event.Kind  `json:"kind"`
+	Message     string      `json:"message,omitempty"`
+	SourceURL   string      `json:"source_url,omitempty"`
+	Line        int         `json:"line,omitempty"`
+	Column      int         `json:"column,omitempty"`
+	Status      IssueStatus `json:"status"`
+	Occurrences uint64      `json:"occurrences"`
+	FirstSeen   time.Time   `json:"first_seen"`
+	LastSeen    time.Time   `json:"last_seen"`
+	LastEvent   event.Event `json:"last_event"`
+}
+
+// ListOptions controls bounded issue pagination.
+type ListOptions struct {
+	Limit  int
+	Offset int
+}
+
+// IssuePage is a stable page of issues and the total matching count.
+type IssuePage struct {
+	Issues []Issue `json:"issues"`
+	Total  int     `json:"total"`
+	Limit  int     `json:"limit"`
+	Offset int     `json:"offset"`
+}
+
+// Store records events and exposes their aggregated issues.
+type Store interface {
+	Record(context.Context, string, event.Event) (Issue, error)
+	GetIssue(context.Context, string, string) (Issue, error)
+	ListIssues(context.Context, string, ListOptions) (IssuePage, error)
+}
+
+func normalizeListOptions(options ListOptions) ListOptions {
+	if options.Limit <= 0 {
+		options.Limit = defaultPageSize
+	}
+	if options.Limit > maxPageSize {
+		options.Limit = maxPageSize
+	}
+	if options.Offset < 0 {
+		options.Offset = 0
+	}
+	return options
+}


### PR DESCRIPTION
## Summary

- introduce the persistence contract for recording events and reading aggregated issues
- group matching fingerprints independently for each project
- track occurrence counts plus first-seen, last-seen, and the latest event
- provide stable last-seen ordering and bounded offset pagination
- return defensive copies so callers cannot mutate stored tag maps
- add concurrency coverage with 100 simultaneous writers

## Scope

This PR contains only the store contract and an in-memory implementation for tests and local development. HTTP ingestion and durable SQLite persistence remain separate changes.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`