### PR TITLE
Add bounded authenticated event ingestion

### DIFF
--- a/cmd/error-tracer/main.go
+++ b/cmd/error-tracer/main.go
@@ -12,11 +12,20 @@ import (
 
 	"github.com/soulteary/Error-Tracer/internal/config"
 	appserver "github.com/soulteary/Error-Tracer/internal/server"
+	"github.com/soulteary/Error-Tracer/internal/store"
 )
 
 func main() {
-	cfg := config.FromEnvironment()
-	app := appserver.New()
+	cfg, err := config.FromEnvironment()
+	if err != nil {
+		slog.Error("invalid configuration", "error", err)
+		os.Exit(1)
+	}
+	app := appserver.New(appserver.Options{
+		Store:     store.NewMemory(),
+		ProjectID: cfg.ProjectID,
+		IngestKey: cfg.IngestKey,
+	})
 
 	httpServer := &http.Server{
 		Addr:              cfg.Address,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"strings"
 	"time"
@@ -15,17 +16,29 @@ const (
 type Config struct {
 	Address         string
 	ShutdownTimeout time.Duration
+	ProjectID       string
+	IngestKey       string
 }
 
 // FromEnvironment loads configuration without mutating process state.
-func FromEnvironment() Config {
+func FromEnvironment() (Config, error) {
 	address := strings.TrimSpace(os.Getenv("ERROR_TRACER_ADDRESS"))
 	if address == "" {
 		address = defaultAddress
+	}
+	projectID := strings.TrimSpace(os.Getenv("ERROR_TRACER_PROJECT_ID"))
+	if projectID == "" {
+		projectID = "default"
+	}
+	ingestKey := strings.TrimSpace(os.Getenv("ERROR_TRACER_INGEST_KEY"))
+	if len(ingestKey) < 16 {
+		return Config{}, errors.New("ERROR_TRACER_INGEST_KEY must contain at least 16 characters")
 	}
 
 	return Config{
 		Address:         address,
 		ShutdownTimeout: defaultShutdownTimeout,
-	}
+		ProjectID:       projectID,
+		IngestKey:       ingestKey,
+	}, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,21 +7,48 @@ import (
 
 func TestFromEnvironmentUsesDefaults(t *testing.T) {
 	t.Setenv("ERROR_TRACER_ADDRESS", "")
+	t.Setenv("ERROR_TRACER_PROJECT_ID", "")
+	t.Setenv("ERROR_TRACER_INGEST_KEY", "development-key-1")
 
-	cfg := FromEnvironment()
+	cfg, err := FromEnvironment()
+	if err != nil {
+		t.Fatalf("FromEnvironment() error = %v", err)
+	}
 	if cfg.Address != ":8080" {
 		t.Fatalf("Address = %q, want %q", cfg.Address, ":8080")
 	}
 	if cfg.ShutdownTimeout != 10*time.Second {
 		t.Fatalf("ShutdownTimeout = %s, want %s", cfg.ShutdownTimeout, 10*time.Second)
 	}
+	if cfg.ProjectID != "default" {
+		t.Fatalf("ProjectID = %q, want %q", cfg.ProjectID, "default")
+	}
 }
 
 func TestFromEnvironmentReadsAddress(t *testing.T) {
 	t.Setenv("ERROR_TRACER_ADDRESS", " 127.0.0.1:9090 ")
+	t.Setenv("ERROR_TRACER_PROJECT_ID", " project-a ")
+	t.Setenv("ERROR_TRACER_INGEST_KEY", "0123456789abcdef")
 
-	cfg := FromEnvironment()
+	cfg, err := FromEnvironment()
+	if err != nil {
+		t.Fatalf("FromEnvironment() error = %v", err)
+	}
 	if cfg.Address != "127.0.0.1:9090" {
 		t.Fatalf("Address = %q, want %q", cfg.Address, "127.0.0.1:9090")
+	}
+	if cfg.ProjectID != "project-a" {
+		t.Fatalf("ProjectID = %q, want %q", cfg.ProjectID, "project-a")
+	}
+	if cfg.IngestKey != "0123456789abcdef" {
+		t.Fatalf("IngestKey was not loaded")
+	}
+}
+
+func TestFromEnvironmentRequiresIngestKey(t *testing.T) {
+	t.Setenv("ERROR_TRACER_INGEST_KEY", "short")
+
+	if _, err := FromEnvironment(); err == nil {
+		t.Fatal("FromEnvironment() error = nil, want invalid ingest key error")
 	}
 }

--- a/internal/server/ingest.go
+++ b/internal/server/ingest.go
@@ -1,0 +1,147 @@
+package server
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+
+	"github.com/soulteary/Error-Tracer/internal/event"
+)
+
+const maxEventBodySize = 128 * 1024
+
+type ingestRequest struct {
+	ProjectKey string      `json:"project_key"`
+	Event      event.Event `json:"event"`
+}
+
+type ingestResponse struct {
+	ID          string `json:"id"`
+	Fingerprint string `json:"fingerprint"`
+}
+
+type errorResponse struct {
+	Error string `json:"error"`
+	Field string `json:"field,omitempty"`
+}
+
+func (s *Server) ingestEvent(w http.ResponseWriter, request *http.Request) {
+	if s.store == nil || s.projectID == "" || s.ingestKey == "" {
+		writeJSON(w, http.StatusServiceUnavailable, errorResponse{Error: "ingest_unavailable"})
+		return
+	}
+	if !supportedMediaType(request.Header.Get("Content-Type")) {
+		writeJSON(w, http.StatusUnsupportedMediaType, errorResponse{Error: "unsupported_media_type"})
+		return
+	}
+
+	request.Body = http.MaxBytesReader(w, request.Body, maxEventBodySize)
+	decoder := json.NewDecoder(request.Body)
+	decoder.DisallowUnknownFields()
+
+	var payload ingestRequest
+	if err := decoder.Decode(&payload); err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, errorResponse{Error: "event_too_large"})
+			return
+		}
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid_json"})
+		return
+	}
+	if err := ensureJSONEnd(decoder); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid_json"})
+		return
+	}
+	if !constantTimeEqual(payload.ProjectKey, s.ingestKey) {
+		writeJSON(w, http.StatusUnauthorized, errorResponse{Error: "invalid_project_key"})
+		return
+	}
+
+	captured := payload.Event
+	captured.ID = ""
+	captured.ReceivedAt = s.now().UTC()
+	captured.UserAgent = request.UserAgent()
+	captured.Normalize()
+	if err := captured.Validate(); err != nil {
+		var validationErr *event.ValidationError
+		if errors.As(err, &validationErr) {
+			writeJSON(w, http.StatusUnprocessableEntity, errorResponse{
+				Error: "invalid_event",
+				Field: validationErr.Field,
+			})
+			return
+		}
+		writeJSON(w, http.StatusUnprocessableEntity, errorResponse{Error: "invalid_event"})
+		return
+	}
+
+	id, err := s.newID()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "internal_error"})
+		return
+	}
+	captured.ID = id
+	issue, err := s.store.Record(request.Context(), s.projectID, captured)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "internal_error"})
+		return
+	}
+
+	writeJSON(w, http.StatusAccepted, ingestResponse{
+		ID:          id,
+		Fingerprint: issue.Fingerprint,
+	})
+}
+
+func supportedMediaType(header string) bool {
+	if strings.TrimSpace(header) == "" {
+		return false
+	}
+	mediaType, _, err := mime.ParseMediaType(header)
+	if err != nil {
+		return false
+	}
+	return mediaType == "application/json" || mediaType == "text/plain"
+}
+
+func ensureJSONEnd(decoder *json.Decoder) error {
+	var extra any
+	err := decoder.Decode(&extra)
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	if err == nil {
+		return errors.New("multiple JSON values")
+	}
+	return err
+}
+
+func constantTimeEqual(left, right string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(left), []byte(right)) == 1
+}
+
+func randomEventID() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", fmt.Errorf("generate event ID: %w", err)
+	}
+	return "evt_" + hex.EncodeToString(value[:]), nil
+}
+
+func writeJSON(w http.ResponseWriter, statusCode int, value any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(statusCode)
+	_ = json.NewEncoder(w).Encode(value)
+}

--- a/internal/server/ingest_test.go
+++ b/internal/server/ingest_test.go
@@ -1,0 +1,202 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/soulteary/Error-Tracer/internal/event"
+	"github.com/soulteary/Error-Tracer/internal/store"
+)
+
+func TestIngestEvent(t *testing.T) {
+	memory := store.NewMemory()
+	app := New(Options{
+		Store:     memory,
+		ProjectID: "project-a",
+		IngestKey: "0123456789abcdef",
+	})
+	receivedAt := time.Date(2026, time.August, 29, 2, 0, 0, 0, time.UTC)
+	app.now = func() time.Time { return receivedAt }
+	app.newID = func() (string, error) { return "evt_test", nil }
+
+	body := `{
+		"project_key":"0123456789abcdef",
+		"event":{
+			"id":"client-controlled",
+			"kind":"error",
+			"message":" boom ",
+			"source_url":"https://example.com/app.js?v=1",
+			"line":10,
+			"received_at":"2020-01-01T00:00:00Z",
+			"user_agent":"client-controlled"
+		}
+	}`
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", "test-agent")
+	response := httptest.NewRecorder()
+
+	app.Handler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d; body = %s", response.Code, http.StatusAccepted, response.Body.String())
+	}
+	var result ingestResponse
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result.ID != "evt_test" || result.Fingerprint == "" {
+		t.Fatalf("response = %#v, want server ID and fingerprint", result)
+	}
+
+	page, err := memory.ListIssues(context.Background(), "project-a", store.ListOptions{})
+	if err != nil {
+		t.Fatalf("list stored issues: %v", err)
+	}
+	if page.Total != 1 {
+		t.Fatalf("stored issues = %d, want 1", page.Total)
+	}
+	stored := page.Issues[0].LastEvent
+	if stored.ID != "evt_test" || !stored.ReceivedAt.Equal(receivedAt) || stored.UserAgent != "test-agent" {
+		t.Fatalf("server-controlled fields = %#v, want overwritten values", stored)
+	}
+	if stored.Message != "boom" || stored.SourceURL != "https://example.com/app.js" {
+		t.Fatalf("normalized event = %#v", stored)
+	}
+}
+
+func TestIngestEventAcceptsBeaconTextPlain(t *testing.T) {
+	app := newTestServer()
+	body := `{"project_key":"0123456789abcdef","event":{"kind":"error","message":"boom"}}`
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(body))
+	request.Header.Set("Content-Type", "text/plain;charset=UTF-8")
+	response := httptest.NewRecorder()
+
+	app.Handler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d; body = %s", response.Code, http.StatusAccepted, response.Body.String())
+	}
+}
+
+func TestIngestEventRejectsInvalidRequests(t *testing.T) {
+	valid := `{"project_key":"0123456789abcdef","event":{"kind":"error","message":"boom"}}`
+	tests := []struct {
+		name        string
+		body        string
+		contentType string
+		wantStatus  int
+		wantError   string
+	}{
+		{name: "media type", body: valid, contentType: "application/xml", wantStatus: http.StatusUnsupportedMediaType, wantError: "unsupported_media_type"},
+		{name: "invalid JSON", body: `{`, contentType: "application/json", wantStatus: http.StatusBadRequest, wantError: "invalid_json"},
+		{name: "unknown field", body: `{"unknown":true}`, contentType: "application/json", wantStatus: http.StatusBadRequest, wantError: "invalid_json"},
+		{name: "multiple values", body: valid + `{}`, contentType: "application/json", wantStatus: http.StatusBadRequest, wantError: "invalid_json"},
+		{name: "project key", body: `{"project_key":"wrong","event":{"kind":"error","message":"boom"}}`, contentType: "application/json", wantStatus: http.StatusUnauthorized, wantError: "invalid_project_key"},
+		{name: "event", body: `{"project_key":"0123456789abcdef","event":{"kind":"error"}}`, contentType: "application/json", wantStatus: http.StatusUnprocessableEntity, wantError: "invalid_event"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			app := newTestServer()
+			request := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(test.body))
+			request.Header.Set("Content-Type", test.contentType)
+			response := httptest.NewRecorder()
+
+			app.Handler().ServeHTTP(response, request)
+
+			if response.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d; body = %s", response.Code, test.wantStatus, response.Body.String())
+			}
+			var result errorResponse
+			if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+				t.Fatalf("decode error response: %v", err)
+			}
+			if result.Error != test.wantError {
+				t.Fatalf("error = %q, want %q", result.Error, test.wantError)
+			}
+		})
+	}
+}
+
+func TestIngestEventRejectsOversizedBody(t *testing.T) {
+	app := newTestServer()
+	body := append([]byte(`{"project_key":"0123456789abcdef","event":{"kind":"error","message":"`), bytes.Repeat([]byte("x"), maxEventBodySize+1)...)
+	body = append(body, []byte(`"}}`)...)
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/events", bytes.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+
+	app.Handler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d; body = %s", response.Code, http.StatusRequestEntityTooLarge, response.Body.String())
+	}
+}
+
+func TestIngestEventRejectsUnconfiguredServer(t *testing.T) {
+	app := New(Options{})
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(`{}`))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+
+	app.Handler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func TestIngestEventReturnsValidationField(t *testing.T) {
+	app := newTestServer()
+	body := `{"project_key":"0123456789abcdef","event":{"kind":"error"}}`
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+
+	app.Handler().ServeHTTP(response, request)
+
+	var result errorResponse
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result.Field != "message" {
+		t.Fatalf("field = %q, want %q", result.Field, "message")
+	}
+}
+
+func TestIngestMethodIsRestricted(t *testing.T) {
+	app := newTestServer()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/events", nil)
+	response := httptest.NewRecorder()
+
+	app.Handler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestRandomEventID(t *testing.T) {
+	id, err := randomEventID()
+	if err != nil {
+		t.Fatalf("randomEventID() error = %v", err)
+	}
+	if !strings.HasPrefix(id, "evt_") || len(id) != len("evt_")+32 {
+		t.Fatalf("id = %q, want evt_ followed by 32 hex characters", id)
+	}
+}
+
+func TestIngestNormalizesBeforeValidation(t *testing.T) {
+	captured := event.Event{Kind: event.KindError, Message: " boom "}
+	captured.Normalize()
+	if err := captured.Validate(); err != nil {
+		t.Fatalf("normalized event validation: %v", err)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,22 +4,44 @@ import (
 	"io"
 	"net/http"
 	"sync/atomic"
+	"time"
+
+	"github.com/soulteary/Error-Tracer/internal/store"
 )
 
 // Server owns the HTTP routes and service readiness state.
 type Server struct {
-	handler http.Handler
-	ready   atomic.Bool
+	handler   http.Handler
+	ready     atomic.Bool
+	store     store.Store
+	projectID string
+	ingestKey string
+	now       func() time.Time
+	newID     func() (string, error)
+}
+
+// Options provides the dependencies required by the HTTP service.
+type Options struct {
+	Store     store.Store
+	ProjectID string
+	IngestKey string
 }
 
 // New creates a service with liveness and readiness endpoints.
-func New() *Server {
-	server := &Server{}
+func New(options Options) *Server {
+	server := &Server{
+		store:     options.Store,
+		projectID: options.ProjectID,
+		ingestKey: options.IngestKey,
+		now:       time.Now,
+		newID:     randomEventID,
+	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", server.health)
 	mux.HandleFunc("GET /readyz", server.readiness)
+	mux.HandleFunc("POST /api/v1/events", server.ingestEvent)
 	server.handler = mux
-	server.ready.Store(true)
+	server.ready.Store(options.Store != nil && options.ProjectID != "" && options.IngestKey != "")
 	return server
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4,10 +4,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/soulteary/Error-Tracer/internal/store"
 )
 
 func TestHealth(t *testing.T) {
-	app := New()
+	app := newTestServer()
 	request := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	response := httptest.NewRecorder()
 
@@ -25,7 +27,7 @@ func TestHealth(t *testing.T) {
 }
 
 func TestReadinessTracksState(t *testing.T) {
-	app := New()
+	app := newTestServer()
 
 	assertStatus := func(want int) {
 		t.Helper()
@@ -43,7 +45,7 @@ func TestReadinessTracksState(t *testing.T) {
 }
 
 func TestHealthRejectsOtherMethods(t *testing.T) {
-	app := New()
+	app := newTestServer()
 	request := httptest.NewRequest(http.MethodPost, "/healthz", nil)
 	response := httptest.NewRecorder()
 
@@ -52,4 +54,12 @@ func TestHealthRejectsOtherMethods(t *testing.T) {
 	if response.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("status = %d, want %d", response.Code, http.StatusMethodNotAllowed)
 	}
+}
+
+func newTestServer() *Server {
+	return New(Options{
+		Store:     store.NewMemory(),
+		ProjectID: "project-a",
+		IngestKey: "0123456789abcdef",
+	})
 }


### PR DESCRIPTION
## Summary

- add `POST /api/v1/events` with a versioned JSON envelope
- authenticate the project key using constant-time comparison
- support `application/json` and sendBeacon-compatible `text/plain`
- cap request bodies at 128 KiB and reject unknown or trailing JSON
- overwrite client-controlled IDs, receipt times, and user agents on the server
- normalize and validate events before recording them
- return a generated event ID and stable issue fingerprint with HTTP 202
- require an explicit ingest key of at least 16 characters at startup

## Security boundary

The browser-facing project key routes events and raises the cost of blind abuse; it is not an administrative secret. Cross-origin policy and rate limiting remain separate hardening changes.

## Scope

This PR contains only configuration and the ingestion endpoint. Durable storage, issue queries, browser SDK, and UI remain separate PRs.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`