### PR TITLE
Use SQLite for runtime persistence

### DIFF
--- a/cmd/error-tracer/main.go
+++ b/cmd/error-tracer/main.go
@@ -21,8 +21,19 @@ func main() {
 		slog.Error("invalid configuration", "error", err)
 		os.Exit(1)
 	}
+	issueStore, err := store.OpenSQLite(context.Background(), cfg.DatabasePath)
+	if err != nil {
+		slog.Error("open issue database", "error", err)
+		os.Exit(1)
+	}
+	defer func() {
+		if err := issueStore.Close(); err != nil {
+			slog.Error("close issue database", "error", err)
+		}
+	}()
+
 	app := appserver.New(appserver.Options{
-		Store:     store.NewMemory(),
+		Store:     issueStore,
 		ProjectID: cfg.ProjectID,
 		IngestKey: cfg.IngestKey,
 	})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,12 +9,14 @@ import (
 
 const (
 	defaultAddress         = ":8080"
+	defaultDatabasePath    = "error-tracer.db"
 	defaultShutdownTimeout = 10 * time.Second
 )
 
 // Config contains process-level settings for the Error-Tracer service.
 type Config struct {
 	Address         string
+	DatabasePath    string
 	ShutdownTimeout time.Duration
 	ProjectID       string
 	IngestKey       string
@@ -25,6 +27,10 @@ func FromEnvironment() (Config, error) {
 	address := strings.TrimSpace(os.Getenv("ERROR_TRACER_ADDRESS"))
 	if address == "" {
 		address = defaultAddress
+	}
+	databasePath := strings.TrimSpace(os.Getenv("ERROR_TRACER_DATABASE_PATH"))
+	if databasePath == "" {
+		databasePath = defaultDatabasePath
 	}
 	projectID := strings.TrimSpace(os.Getenv("ERROR_TRACER_PROJECT_ID"))
 	if projectID == "" {
@@ -37,6 +43,7 @@ func FromEnvironment() (Config, error) {
 
 	return Config{
 		Address:         address,
+		DatabasePath:    databasePath,
 		ShutdownTimeout: defaultShutdownTimeout,
 		ProjectID:       projectID,
 		IngestKey:       ingestKey,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,7 @@ import (
 
 func TestFromEnvironmentUsesDefaults(t *testing.T) {
 	t.Setenv("ERROR_TRACER_ADDRESS", "")
+	t.Setenv("ERROR_TRACER_DATABASE_PATH", "")
 	t.Setenv("ERROR_TRACER_PROJECT_ID", "")
 	t.Setenv("ERROR_TRACER_INGEST_KEY", "development-key-1")
 
@@ -16,6 +17,9 @@ func TestFromEnvironmentUsesDefaults(t *testing.T) {
 	}
 	if cfg.Address != ":8080" {
 		t.Fatalf("Address = %q, want %q", cfg.Address, ":8080")
+	}
+	if cfg.DatabasePath != "error-tracer.db" {
+		t.Fatalf("DatabasePath = %q, want %q", cfg.DatabasePath, "error-tracer.db")
 	}
 	if cfg.ShutdownTimeout != 10*time.Second {
 		t.Fatalf("ShutdownTimeout = %s, want %s", cfg.ShutdownTimeout, 10*time.Second)
@@ -27,6 +31,7 @@ func TestFromEnvironmentUsesDefaults(t *testing.T) {
 
 func TestFromEnvironmentReadsAddress(t *testing.T) {
 	t.Setenv("ERROR_TRACER_ADDRESS", " 127.0.0.1:9090 ")
+	t.Setenv("ERROR_TRACER_DATABASE_PATH", " /var/lib/error-tracer/events.db ")
 	t.Setenv("ERROR_TRACER_PROJECT_ID", " project-a ")
 	t.Setenv("ERROR_TRACER_INGEST_KEY", "0123456789abcdef")
 
@@ -36,6 +41,9 @@ func TestFromEnvironmentReadsAddress(t *testing.T) {
 	}
 	if cfg.Address != "127.0.0.1:9090" {
 		t.Fatalf("Address = %q, want %q", cfg.Address, "127.0.0.1:9090")
+	}
+	if cfg.DatabasePath != "/var/lib/error-tracer/events.db" {
+		t.Fatalf("DatabasePath = %q, want trimmed path", cfg.DatabasePath)
 	}
 	if cfg.ProjectID != "project-a" {
 		t.Fatalf("ProjectID = %q, want %q", cfg.ProjectID, "project-a")


### PR DESCRIPTION
## Summary

- add `ERROR_TRACER_DATABASE_PATH` with an `error-tracer.db` default
- open and migrate the SQLite store before accepting traffic
- fail fast when the database cannot be opened
- close the database during process teardown
- replace the ephemeral runtime store while keeping the memory adapter for tests

## Scope

This PR only wires the already-reviewed SQLite adapter into configuration and process lifecycle. It does not add query endpoints, migrations beyond the existing schema, or deployment files.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`