### PR TITLE
Add the authenticated issue read API

### DIFF
--- a/cmd/error-tracer/main.go
+++ b/cmd/error-tracer/main.go
@@ -33,9 +33,10 @@ func main() {
 	}()
 
 	app := appserver.New(appserver.Options{
-		Store:     issueStore,
-		ProjectID: cfg.ProjectID,
-		IngestKey: cfg.IngestKey,
+		Store:      issueStore,
+		ProjectID:  cfg.ProjectID,
+		IngestKey:  cfg.IngestKey,
+		AdminToken: cfg.AdminToken,
 	})
 
 	httpServer := &http.Server{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	ShutdownTimeout time.Duration
 	ProjectID       string
 	IngestKey       string
+	AdminToken      string
 }
 
 // FromEnvironment loads configuration without mutating process state.
@@ -40,6 +41,10 @@ func FromEnvironment() (Config, error) {
 	if len(ingestKey) < 16 {
 		return Config{}, errors.New("ERROR_TRACER_INGEST_KEY must contain at least 16 characters")
 	}
+	adminToken := strings.TrimSpace(os.Getenv("ERROR_TRACER_ADMIN_TOKEN"))
+	if len(adminToken) < 24 {
+		return Config{}, errors.New("ERROR_TRACER_ADMIN_TOKEN must contain at least 24 characters")
+	}
 
 	return Config{
 		Address:         address,
@@ -47,5 +52,6 @@ func FromEnvironment() (Config, error) {
 		ShutdownTimeout: defaultShutdownTimeout,
 		ProjectID:       projectID,
 		IngestKey:       ingestKey,
+		AdminToken:      adminToken,
 	}, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,6 +10,7 @@ func TestFromEnvironmentUsesDefaults(t *testing.T) {
 	t.Setenv("ERROR_TRACER_DATABASE_PATH", "")
 	t.Setenv("ERROR_TRACER_PROJECT_ID", "")
 	t.Setenv("ERROR_TRACER_INGEST_KEY", "development-key-1")
+	t.Setenv("ERROR_TRACER_ADMIN_TOKEN", "development-admin-token-1")
 
 	cfg, err := FromEnvironment()
 	if err != nil {
@@ -34,6 +35,7 @@ func TestFromEnvironmentReadsAddress(t *testing.T) {
 	t.Setenv("ERROR_TRACER_DATABASE_PATH", " /var/lib/error-tracer/events.db ")
 	t.Setenv("ERROR_TRACER_PROJECT_ID", " project-a ")
 	t.Setenv("ERROR_TRACER_INGEST_KEY", "0123456789abcdef")
+	t.Setenv("ERROR_TRACER_ADMIN_TOKEN", " 0123456789abcdefghijklmn ")
 
 	cfg, err := FromEnvironment()
 	if err != nil {
@@ -51,12 +53,25 @@ func TestFromEnvironmentReadsAddress(t *testing.T) {
 	if cfg.IngestKey != "0123456789abcdef" {
 		t.Fatalf("IngestKey was not loaded")
 	}
+	if cfg.AdminToken != "0123456789abcdefghijklmn" {
+		t.Fatalf("AdminToken was not loaded")
+	}
 }
 
 func TestFromEnvironmentRequiresIngestKey(t *testing.T) {
 	t.Setenv("ERROR_TRACER_INGEST_KEY", "short")
+	t.Setenv("ERROR_TRACER_ADMIN_TOKEN", "0123456789abcdefghijklmn")
 
 	if _, err := FromEnvironment(); err == nil {
 		t.Fatal("FromEnvironment() error = nil, want invalid ingest key error")
+	}
+}
+
+func TestFromEnvironmentRequiresAdminToken(t *testing.T) {
+	t.Setenv("ERROR_TRACER_INGEST_KEY", "0123456789abcdef")
+	t.Setenv("ERROR_TRACER_ADMIN_TOKEN", "short")
+
+	if _, err := FromEnvironment(); err == nil {
+		t.Fatal("FromEnvironment() error = nil, want invalid admin token error")
 	}
 }

--- a/internal/server/issues.go
+++ b/internal/server/issues.go
@@ -1,0 +1,103 @@
+package server
+
+import (
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/soulteary/Error-Tracer/internal/store"
+)
+
+const maxIssueOffset = 100_000
+
+type issueResponse struct {
+	Issue store.Issue `json:"issue"`
+}
+
+func (s *Server) listIssues(w http.ResponseWriter, request *http.Request) {
+	if !s.authorizeAdmin(w, request) {
+		return
+	}
+	options, err := parseListOptions(request)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid_pagination"})
+		return
+	}
+
+	page, err := s.store.ListIssues(request.Context(), s.projectID, options)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "internal_error"})
+		return
+	}
+	writeJSON(w, http.StatusOK, page)
+}
+
+func (s *Server) getIssue(w http.ResponseWriter, request *http.Request) {
+	if !s.authorizeAdmin(w, request) {
+		return
+	}
+	fingerprint := request.PathValue("fingerprint")
+	if !validFingerprint(fingerprint) {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid_fingerprint"})
+		return
+	}
+
+	issue, err := s.store.GetIssue(request.Context(), s.projectID, fingerprint)
+	if errors.Is(err, store.ErrIssueNotFound) {
+		writeJSON(w, http.StatusNotFound, errorResponse{Error: "issue_not_found"})
+		return
+	}
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "internal_error"})
+		return
+	}
+	writeJSON(w, http.StatusOK, issueResponse{Issue: issue})
+}
+
+func (s *Server) authorizeAdmin(w http.ResponseWriter, request *http.Request) bool {
+	if s.store == nil || s.projectID == "" || s.adminToken == "" {
+		writeJSON(w, http.StatusServiceUnavailable, errorResponse{Error: "admin_unavailable"})
+		return false
+	}
+	scheme, token, found := strings.Cut(request.Header.Get("Authorization"), " ")
+	if !found || !strings.EqualFold(scheme, "Bearer") || !constantTimeEqual(token, s.adminToken) {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="error-tracer"`)
+		writeJSON(w, http.StatusUnauthorized, errorResponse{Error: "unauthorized"})
+		return false
+	}
+	return true
+}
+
+func parseListOptions(request *http.Request) (store.ListOptions, error) {
+	query := request.URL.Query()
+	if len(query["limit"]) > 1 || len(query["offset"]) > 1 {
+		return store.ListOptions{}, errors.New("pagination parameters must not be repeated")
+	}
+
+	var options store.ListOptions
+	if raw := query.Get("limit"); raw != "" {
+		limit, err := strconv.Atoi(raw)
+		if err != nil || limit < 1 || limit > 100 {
+			return store.ListOptions{}, errors.New("limit must be between 1 and 100")
+		}
+		options.Limit = limit
+	}
+	if raw := query.Get("offset"); raw != "" {
+		offset, err := strconv.Atoi(raw)
+		if err != nil || offset < 0 || offset > maxIssueOffset {
+			return store.ListOptions{}, errors.New("offset is out of range")
+		}
+		options.Offset = offset
+	}
+	return options, nil
+}
+
+func validFingerprint(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil && strings.ToLower(value) == value
+}

--- a/internal/server/issues_test.go
+++ b/internal/server/issues_test.go
@@ -1,0 +1,159 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/soulteary/Error-Tracer/internal/event"
+	"github.com/soulteary/Error-Tracer/internal/store"
+)
+
+const testAdminToken = "0123456789abcdefghijklmn"
+
+func TestListIssuesRequiresAdminToken(t *testing.T) {
+	tests := []struct {
+		name          string
+		authorization string
+	}{
+		{name: "missing"},
+		{name: "wrong scheme", authorization: "Basic " + testAdminToken},
+		{name: "wrong token", authorization: "Bearer wrong-token"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, "/api/v1/issues", nil)
+			request.Header.Set("Authorization", test.authorization)
+			response := httptest.NewRecorder()
+
+			newTestServer().Handler().ServeHTTP(response, request)
+
+			if response.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusUnauthorized)
+			}
+			if response.Header().Get("WWW-Authenticate") == "" {
+				t.Fatal("WWW-Authenticate header is empty")
+			}
+		})
+	}
+}
+
+func TestListIssuesReturnsBoundedPage(t *testing.T) {
+	memory := store.NewMemory()
+	base := time.Date(2026, time.August, 29, 2, 0, 0, 0, time.UTC)
+	for index, message := range []string{"first", "second", "third"} {
+		captured := event.Event{
+			Kind:       event.KindError,
+			Message:    message,
+			ReceivedAt: base.Add(time.Duration(index) * time.Minute),
+		}
+		if _, err := memory.Record(context.Background(), "project-a", captured); err != nil {
+			t.Fatalf("record issue: %v", err)
+		}
+	}
+	app := New(Options{
+		Store: memory, ProjectID: "project-a", IngestKey: "0123456789abcdef", AdminToken: testAdminToken,
+	})
+	request := authorizedRequest(http.MethodGet, "/api/v1/issues?limit=1&offset=1")
+	response := httptest.NewRecorder()
+
+	app.Handler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", response.Code, http.StatusOK, response.Body.String())
+	}
+	var page store.IssuePage
+	if err := json.NewDecoder(response.Body).Decode(&page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if page.Total != 3 || page.Limit != 1 || page.Offset != 1 || len(page.Issues) != 1 {
+		t.Fatalf("page = %#v", page)
+	}
+	if page.Issues[0].Message != "second" {
+		t.Fatalf("message = %q, want second", page.Issues[0].Message)
+	}
+}
+
+func TestListIssuesRejectsInvalidPagination(t *testing.T) {
+	for _, target := range []string{
+		"/api/v1/issues?limit=0",
+		"/api/v1/issues?limit=101",
+		"/api/v1/issues?limit=nope",
+		"/api/v1/issues?limit=1&limit=2",
+		"/api/v1/issues?offset=-1",
+		"/api/v1/issues?offset=100001",
+	} {
+		t.Run(target, func(t *testing.T) {
+			response := httptest.NewRecorder()
+			newTestServer().Handler().ServeHTTP(response, authorizedRequest(http.MethodGet, target))
+			if response.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusBadRequest)
+			}
+		})
+	}
+}
+
+func TestGetIssue(t *testing.T) {
+	memory := store.NewMemory()
+	captured := event.Event{Kind: event.KindError, Message: "boom", ReceivedAt: time.Now().UTC()}
+	stored, err := memory.Record(context.Background(), "project-a", captured)
+	if err != nil {
+		t.Fatalf("record issue: %v", err)
+	}
+	app := New(Options{
+		Store: memory, ProjectID: "project-a", IngestKey: "0123456789abcdef", AdminToken: testAdminToken,
+	})
+	request := authorizedRequest(http.MethodGet, "/api/v1/issues/"+stored.Fingerprint)
+	response := httptest.NewRecorder()
+
+	app.Handler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", response.Code, http.StatusOK, response.Body.String())
+	}
+	var result issueResponse
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		t.Fatalf("decode issue: %v", err)
+	}
+	if result.Issue.Fingerprint != stored.Fingerprint {
+		t.Fatalf("fingerprint = %q, want %q", result.Issue.Fingerprint, stored.Fingerprint)
+	}
+}
+
+func TestGetIssueRejectsInvalidOrMissingFingerprint(t *testing.T) {
+	tests := []struct {
+		fingerprint string
+		wantStatus  int
+	}{
+		{fingerprint: "not-a-fingerprint", wantStatus: http.StatusBadRequest},
+		{fingerprint: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", wantStatus: http.StatusBadRequest},
+		{fingerprint: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", wantStatus: http.StatusNotFound},
+	}
+	for _, test := range tests {
+		request := authorizedRequest(http.MethodGet, "/api/v1/issues/"+test.fingerprint)
+		response := httptest.NewRecorder()
+		newTestServer().Handler().ServeHTTP(response, request)
+		if response.Code != test.wantStatus {
+			t.Fatalf("fingerprint %q: status = %d, want %d", test.fingerprint, response.Code, test.wantStatus)
+		}
+	}
+}
+
+func TestIssuesAPIRejectsUnconfiguredServer(t *testing.T) {
+	request := authorizedRequest(http.MethodGet, "/api/v1/issues")
+	response := httptest.NewRecorder()
+	New(Options{}).Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func authorizedRequest(method, target string) *http.Request {
+	request := httptest.NewRequest(method, target, nil)
+	request.Header.Set("Authorization", "Bearer "+testAdminToken)
+	return request
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,37 +11,42 @@ import (
 
 // Server owns the HTTP routes and service readiness state.
 type Server struct {
-	handler   http.Handler
-	ready     atomic.Bool
-	store     store.Store
-	projectID string
-	ingestKey string
-	now       func() time.Time
-	newID     func() (string, error)
+	handler    http.Handler
+	ready      atomic.Bool
+	store      store.Store
+	projectID  string
+	ingestKey  string
+	adminToken string
+	now        func() time.Time
+	newID      func() (string, error)
 }
 
 // Options provides the dependencies required by the HTTP service.
 type Options struct {
-	Store     store.Store
-	ProjectID string
-	IngestKey string
+	Store      store.Store
+	ProjectID  string
+	IngestKey  string
+	AdminToken string
 }
 
 // New creates a service with liveness and readiness endpoints.
 func New(options Options) *Server {
 	server := &Server{
-		store:     options.Store,
-		projectID: options.ProjectID,
-		ingestKey: options.IngestKey,
-		now:       time.Now,
-		newID:     randomEventID,
+		store:      options.Store,
+		projectID:  options.ProjectID,
+		ingestKey:  options.IngestKey,
+		adminToken: options.AdminToken,
+		now:        time.Now,
+		newID:      randomEventID,
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", server.health)
 	mux.HandleFunc("GET /readyz", server.readiness)
 	mux.HandleFunc("POST /api/v1/events", server.ingestEvent)
+	mux.HandleFunc("GET /api/v1/issues", server.listIssues)
+	mux.HandleFunc("GET /api/v1/issues/{fingerprint}", server.getIssue)
 	server.handler = mux
-	server.ready.Store(options.Store != nil && options.ProjectID != "" && options.IngestKey != "")
+	server.ready.Store(options.Store != nil && options.ProjectID != "" && options.IngestKey != "" && options.AdminToken != "")
 	return server
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -58,8 +58,9 @@ func TestHealthRejectsOtherMethods(t *testing.T) {
 
 func newTestServer() *Server {
 	return New(Options{
-		Store:     store.NewMemory(),
-		ProjectID: "project-a",
-		IngestKey: "0123456789abcdef",
+		Store:      store.NewMemory(),
+		ProjectID:  "project-a",
+		IngestKey:  "0123456789abcdef",
+		AdminToken: "0123456789abcdefghijklmn",
 	})
 }


### PR DESCRIPTION
## Summary

- require a separate admin token of at least 24 characters
- expose `GET /api/v1/issues` with bounded limit/offset pagination
- expose `GET /api/v1/issues/{fingerprint}` for issue detail
- validate pagination and canonical lowercase SHA-256 fingerprints
- isolate all reads to the configured project
- use Bearer authentication and constant-time credential comparison
- return cache-disabled JSON and an explicit authentication challenge

## Security boundary

The admin token is distinct from the browser-visible ingest key. It is supplied only in the `Authorization` header and is never accepted in a URL or request body.

## Scope

This PR adds read-only administration. Status changes, filtering, dashboard assets, and cross-origin ingestion policy remain separate PRs.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`