### PR TITLE
Add issue status management

### DIFF
--- a/internal/server/issues.go
+++ b/internal/server/issues.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"errors"
+	"mime"
 	"net/http"
 	"strconv"
 	"strings"
@@ -10,10 +12,17 @@ import (
 	"github.com/soulteary/Error-Tracer/internal/store"
 )
 
-const maxIssueOffset = 100_000
+const (
+	maxIssueOffset         = 100_000
+	maxIssueUpdateBodySize = 4 * 1024
+)
 
 type issueResponse struct {
 	Issue store.Issue `json:"issue"`
+}
+
+type issueUpdateRequest struct {
+	Status store.IssueStatus `json:"status"`
 }
 
 func (s *Server) listIssues(w http.ResponseWriter, request *http.Request) {
@@ -45,6 +54,54 @@ func (s *Server) getIssue(w http.ResponseWriter, request *http.Request) {
 	}
 
 	issue, err := s.store.GetIssue(request.Context(), s.projectID, fingerprint)
+	if errors.Is(err, store.ErrIssueNotFound) {
+		writeJSON(w, http.StatusNotFound, errorResponse{Error: "issue_not_found"})
+		return
+	}
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "internal_error"})
+		return
+	}
+	writeJSON(w, http.StatusOK, issueResponse{Issue: issue})
+}
+
+func (s *Server) updateIssue(w http.ResponseWriter, request *http.Request) {
+	if !s.authorizeAdmin(w, request) {
+		return
+	}
+	fingerprint := request.PathValue("fingerprint")
+	if !validFingerprint(fingerprint) {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid_fingerprint"})
+		return
+	}
+	if !isJSONMediaType(request.Header.Get("Content-Type")) {
+		writeJSON(w, http.StatusUnsupportedMediaType, errorResponse{Error: "unsupported_media_type"})
+		return
+	}
+
+	request.Body = http.MaxBytesReader(w, request.Body, maxIssueUpdateBodySize)
+	decoder := json.NewDecoder(request.Body)
+	decoder.DisallowUnknownFields()
+	var payload issueUpdateRequest
+	if err := decoder.Decode(&payload); err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, errorResponse{Error: "request_too_large"})
+			return
+		}
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid_json"})
+		return
+	}
+	if err := ensureJSONEnd(decoder); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid_json"})
+		return
+	}
+	if !payload.Status.Valid() {
+		writeJSON(w, http.StatusUnprocessableEntity, errorResponse{Error: "invalid_status", Field: "status"})
+		return
+	}
+
+	issue, err := s.store.SetIssueStatus(request.Context(), s.projectID, fingerprint, payload.Status)
 	if errors.Is(err, store.ErrIssueNotFound) {
 		writeJSON(w, http.StatusNotFound, errorResponse{Error: "issue_not_found"})
 		return
@@ -100,4 +157,9 @@ func validFingerprint(value string) bool {
 	}
 	_, err := hex.DecodeString(value)
 	return err == nil && strings.ToLower(value) == value
+}
+
+func isJSONMediaType(header string) bool {
+	mediaType, _, err := mime.ParseMediaType(header)
+	return err == nil && mediaType == "application/json"
 }

--- a/internal/server/issues_test.go
+++ b/internal/server/issues_test.go
@@ -1,10 +1,13 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -149,6 +152,70 @@ func TestIssuesAPIRejectsUnconfiguredServer(t *testing.T) {
 	New(Options{}).Handler().ServeHTTP(response, request)
 	if response.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want %d", response.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func TestUpdateIssueStatus(t *testing.T) {
+	memory := store.NewMemory()
+	captured := event.Event{Kind: event.KindError, Message: "boom", ReceivedAt: time.Now().UTC()}
+	stored, err := memory.Record(context.Background(), "project-a", captured)
+	if err != nil {
+		t.Fatalf("record issue: %v", err)
+	}
+	app := New(Options{
+		Store: memory, ProjectID: "project-a", IngestKey: "0123456789abcdef", AdminToken: testAdminToken,
+	})
+	request := authorizedRequest(http.MethodPatch, "/api/v1/issues/"+stored.Fingerprint)
+	request.Header.Set("Content-Type", "application/json; charset=utf-8")
+	request.Body = io.NopCloser(strings.NewReader(`{"status":"resolved"}`))
+	response := httptest.NewRecorder()
+
+	app.Handler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", response.Code, http.StatusOK, response.Body.String())
+	}
+	persisted, err := memory.GetIssue(context.Background(), "project-a", stored.Fingerprint)
+	if err != nil {
+		t.Fatalf("get issue: %v", err)
+	}
+	if persisted.Status != store.IssueStatusResolved {
+		t.Fatalf("status = %q, want %q", persisted.Status, store.IssueStatusResolved)
+	}
+}
+
+func TestUpdateIssueRejectsInvalidRequests(t *testing.T) {
+	validFingerprint := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	oversized := append([]byte(`{"status":"`), bytes.Repeat([]byte("x"), maxIssueUpdateBodySize+1)...)
+	oversized = append(oversized, []byte(`"}`)...)
+	tests := []struct {
+		name        string
+		fingerprint string
+		contentType string
+		body        []byte
+		wantStatus  int
+	}{
+		{name: "fingerprint", fingerprint: "invalid", contentType: "application/json", body: []byte(`{"status":"open"}`), wantStatus: http.StatusBadRequest},
+		{name: "media type", fingerprint: validFingerprint, contentType: "text/plain", body: []byte(`{"status":"open"}`), wantStatus: http.StatusUnsupportedMediaType},
+		{name: "JSON", fingerprint: validFingerprint, contentType: "application/json", body: []byte(`{`), wantStatus: http.StatusBadRequest},
+		{name: "unknown field", fingerprint: validFingerprint, contentType: "application/json", body: []byte(`{"other":true}`), wantStatus: http.StatusBadRequest},
+		{name: "multiple values", fingerprint: validFingerprint, contentType: "application/json", body: []byte(`{"status":"open"}{}`), wantStatus: http.StatusBadRequest},
+		{name: "status", fingerprint: validFingerprint, contentType: "application/json", body: []byte(`{"status":"closed"}`), wantStatus: http.StatusUnprocessableEntity},
+		{name: "too large", fingerprint: validFingerprint, contentType: "application/json", body: oversized, wantStatus: http.StatusRequestEntityTooLarge},
+		{name: "missing", fingerprint: validFingerprint, contentType: "application/json", body: []byte(`{"status":"open"}`), wantStatus: http.StatusNotFound},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := authorizedRequest(http.MethodPatch, "/api/v1/issues/"+test.fingerprint)
+			request.Header.Set("Content-Type", test.contentType)
+			request.Body = io.NopCloser(bytes.NewReader(test.body))
+			response := httptest.NewRecorder()
+
+			newTestServer().Handler().ServeHTTP(response, request)
+			if response.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d; body = %s", response.Code, test.wantStatus, response.Body.String())
+			}
+		})
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -45,6 +45,7 @@ func New(options Options) *Server {
 	mux.HandleFunc("POST /api/v1/events", server.ingestEvent)
 	mux.HandleFunc("GET /api/v1/issues", server.listIssues)
 	mux.HandleFunc("GET /api/v1/issues/{fingerprint}", server.getIssue)
+	mux.HandleFunc("PATCH /api/v1/issues/{fingerprint}", server.updateIssue)
 	server.handler = mux
 	server.ready.Store(options.Store != nil && options.ProjectID != "" && options.IngestKey != "" && options.AdminToken != "")
 	return server

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -126,6 +126,31 @@ func (m *Memory) ListIssues(ctx context.Context, projectID string, options ListO
 	}, nil
 }
 
+// SetIssueStatus updates the triage state of one issue.
+func (m *Memory) SetIssueStatus(ctx context.Context, projectID, fingerprint string, status IssueStatus) (Issue, error) {
+	if err := ctx.Err(); err != nil {
+		return Issue{}, err
+	}
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return Issue{}, ErrProjectRequired
+	}
+	if !status.Valid() {
+		return Issue{}, ErrInvalidStatus
+	}
+
+	key := issueKey(projectID, fingerprint)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	issue, exists := m.issues[key]
+	if !exists {
+		return Issue{}, ErrIssueNotFound
+	}
+	issue.Status = status
+	m.issues[key] = issue
+	return cloneIssue(issue), nil
+}
+
 func issueKey(projectID, fingerprint string) string {
 	return projectID + "\x00" + fingerprint
 }

--- a/internal/store/memory_test.go
+++ b/internal/store/memory_test.go
@@ -136,6 +136,39 @@ func TestMemoryReturnsDefensiveCopies(t *testing.T) {
 	}
 }
 
+func TestMemorySetIssueStatus(t *testing.T) {
+	memory := NewMemory()
+	captured := testEvent(time.Now())
+	stored, err := memory.Record(context.Background(), "project-a", captured)
+	if err != nil {
+		t.Fatalf("record event: %v", err)
+	}
+
+	updated, err := memory.SetIssueStatus(
+		context.Background(), "project-a", stored.Fingerprint, IssueStatusResolved,
+	)
+	if err != nil {
+		t.Fatalf("set issue status: %v", err)
+	}
+	if updated.Status != IssueStatusResolved {
+		t.Fatalf("status = %q, want %q", updated.Status, IssueStatusResolved)
+	}
+	persisted, err := memory.GetIssue(context.Background(), "project-a", stored.Fingerprint)
+	if err != nil {
+		t.Fatalf("get issue: %v", err)
+	}
+	if persisted.Status != IssueStatusResolved {
+		t.Fatalf("persisted status = %q, want %q", persisted.Status, IssueStatusResolved)
+	}
+
+	if _, err := memory.SetIssueStatus(context.Background(), "project-a", stored.Fingerprint, "closed"); !errors.Is(err, ErrInvalidStatus) {
+		t.Fatalf("invalid status error = %v, want ErrInvalidStatus", err)
+	}
+	if _, err := memory.SetIssueStatus(context.Background(), "project-a", "missing", IssueStatusIgnored); !errors.Is(err, ErrIssueNotFound) {
+		t.Fatalf("missing issue error = %v, want ErrIssueNotFound", err)
+	}
+}
+
 func TestMemoryRejectsInvalidInputAndCancelledContext(t *testing.T) {
 	memory := NewMemory()
 	captured := testEvent(time.Now())

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -218,6 +218,48 @@ LIMIT ? OFFSET ?
 	}, nil
 }
 
+// SetIssueStatus updates the triage state of one issue.
+func (s *SQLite) SetIssueStatus(ctx context.Context, projectID, fingerprint string, status IssueStatus) (Issue, error) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return Issue{}, ErrProjectRequired
+	}
+	if !status.Valid() {
+		return Issue{}, ErrInvalidStatus
+	}
+	if err := ctx.Err(); err != nil {
+		return Issue{}, err
+	}
+
+	transaction, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Issue{}, fmt.Errorf("begin status transaction: %w", err)
+	}
+	defer func() { _ = transaction.Rollback() }()
+	result, err := transaction.ExecContext(ctx, `
+UPDATE issues SET status = ? WHERE project_id = ? AND fingerprint = ?
+`, status, projectID, fingerprint)
+	if err != nil {
+		return Issue{}, fmt.Errorf("update issue status: %w", err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return Issue{}, fmt.Errorf("read updated row count: %w", err)
+	}
+	if rowsAffected == 0 {
+		return Issue{}, ErrIssueNotFound
+	}
+
+	issue, err := queryIssue(ctx, transaction, projectID, fingerprint)
+	if err != nil {
+		return Issue{}, err
+	}
+	if err := transaction.Commit(); err != nil {
+		return Issue{}, fmt.Errorf("commit status transaction: %w", err)
+	}
+	return issue, nil
+}
+
 type rowQuerier interface {
 	QueryRowContext(context.Context, string, ...any) *sql.Row
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -157,6 +157,44 @@ func TestSQLiteRejectsInvalidInputAndMapsMissingIssue(t *testing.T) {
 	}
 }
 
+func TestSQLiteSetIssueStatusPersists(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "error-tracer.db")
+	database := openTestSQLite(t, path)
+	captured := testEvent(time.Now().UTC())
+	stored, err := database.Record(context.Background(), "project-a", captured)
+	if err != nil {
+		t.Fatalf("record issue: %v", err)
+	}
+	updated, err := database.SetIssueStatus(
+		context.Background(), "project-a", stored.Fingerprint, IssueStatusIgnored,
+	)
+	if err != nil {
+		t.Fatalf("set issue status: %v", err)
+	}
+	if updated.Status != IssueStatusIgnored {
+		t.Fatalf("status = %q, want %q", updated.Status, IssueStatusIgnored)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatalf("close database: %v", err)
+	}
+
+	reopened := openTestSQLite(t, path)
+	t.Cleanup(func() { _ = reopened.Close() })
+	persisted, err := reopened.GetIssue(context.Background(), "project-a", stored.Fingerprint)
+	if err != nil {
+		t.Fatalf("get issue: %v", err)
+	}
+	if persisted.Status != IssueStatusIgnored {
+		t.Fatalf("persisted status = %q, want %q", persisted.Status, IssueStatusIgnored)
+	}
+	if _, err := reopened.SetIssueStatus(context.Background(), "project-a", stored.Fingerprint, "closed"); !errors.Is(err, ErrInvalidStatus) {
+		t.Fatalf("invalid status error = %v, want ErrInvalidStatus", err)
+	}
+	if _, err := reopened.SetIssueStatus(context.Background(), "project-a", "missing", IssueStatusOpen); !errors.Is(err, ErrIssueNotFound) {
+		t.Fatalf("missing issue error = %v, want ErrIssueNotFound", err)
+	}
+}
+
 func openTestSQLite(t *testing.T, path string) *SQLite {
 	t.Helper()
 	database, err := OpenSQLite(context.Background(), path)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -16,6 +16,7 @@ const (
 
 var (
 	ErrIssueNotFound   = errors.New("issue not found")
+	ErrInvalidStatus   = errors.New("invalid issue status")
 	ErrProjectRequired = errors.New("project ID is required")
 	ErrReceivedAtEmpty = errors.New("event received_at is required")
 )
@@ -28,6 +29,16 @@ const (
 	IssueStatusResolved IssueStatus = "resolved"
 	IssueStatusIgnored  IssueStatus = "ignored"
 )
+
+// Valid reports whether the status can be persisted.
+func (status IssueStatus) Valid() bool {
+	switch status {
+	case IssueStatusOpen, IssueStatusResolved, IssueStatusIgnored:
+		return true
+	default:
+		return false
+	}
+}
 
 // Issue is the server-side aggregation of events with the same fingerprint.
 type Issue struct {
@@ -64,6 +75,7 @@ type Store interface {
 	Record(context.Context, string, event.Event) (Issue, error)
 	GetIssue(context.Context, string, string) (Issue, error)
 	ListIssues(context.Context, string, ListOptions) (IssuePage, error)
+	SetIssueStatus(context.Context, string, string, IssueStatus) (Issue, error)
 }
 
 func normalizeListOptions(options ListOptions) ListOptions {


### PR DESCRIPTION
## Summary

- add the `open`, `resolved`, and `ignored` issue states
- expose `PATCH /api/v1/issues/{fingerprint}` for authenticated state changes
- implement atomic state updates in the memory and SQLite stores
- return the updated issue and reject unknown issues or invalid request bodies
- keep project isolation and the existing admin authentication boundary

## Scope

This PR only adds issue state changes. Status filtering, browser SDK delivery, and the dashboard remain separate PRs.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`

The branch is one commit ahead of `master` and changes only the eight status-management files.