### PR TITLE
Enforce an event origin allowlist

### DIFF
--- a/cmd/error-tracer/main.go
+++ b/cmd/error-tracer/main.go
@@ -33,10 +33,11 @@ func main() {
 	}()
 
 	app := appserver.New(appserver.Options{
-		Store:      issueStore,
-		ProjectID:  cfg.ProjectID,
-		IngestKey:  cfg.IngestKey,
-		AdminToken: cfg.AdminToken,
+		Store:          issueStore,
+		ProjectID:      cfg.ProjectID,
+		IngestKey:      cfg.IngestKey,
+		AdminToken:     cfg.AdminToken,
+		AllowedOrigins: cfg.AllowedOrigins,
 	})
 
 	httpServer := &http.Server{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"errors"
+	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -21,6 +23,7 @@ type Config struct {
 	ProjectID       string
 	IngestKey       string
 	AdminToken      string
+	AllowedOrigins  []string
 }
 
 // FromEnvironment loads configuration without mutating process state.
@@ -45,6 +48,10 @@ func FromEnvironment() (Config, error) {
 	if len(adminToken) < 24 {
 		return Config{}, errors.New("ERROR_TRACER_ADMIN_TOKEN must contain at least 24 characters")
 	}
+	allowedOrigins, err := parseOrigins(os.Getenv("ERROR_TRACER_ALLOWED_ORIGINS"))
+	if err != nil {
+		return Config{}, err
+	}
 
 	return Config{
 		Address:         address,
@@ -53,5 +60,37 @@ func FromEnvironment() (Config, error) {
 		ProjectID:       projectID,
 		IngestKey:       ingestKey,
 		AdminToken:      adminToken,
+		AllowedOrigins:  allowedOrigins,
 	}, nil
+}
+
+func parseOrigins(value string) ([]string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+
+	origins := make([]string, 0, strings.Count(value, ",")+1)
+	seen := make(map[string]struct{})
+	for _, raw := range strings.Split(value, ",") {
+		raw = strings.TrimSpace(raw)
+		parsed, err := url.Parse(raw)
+		if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+			return nil, fmt.Errorf("ERROR_TRACER_ALLOWED_ORIGINS contains invalid origin %q", raw)
+		}
+		scheme := strings.ToLower(parsed.Scheme)
+		if scheme != "http" && scheme != "https" {
+			return nil, fmt.Errorf("ERROR_TRACER_ALLOWED_ORIGINS origin %q must use http or https", raw)
+		}
+		if parsed.User != nil || (parsed.Path != "" && parsed.Path != "/") || parsed.RawQuery != "" || parsed.Fragment != "" {
+			return nil, fmt.Errorf("ERROR_TRACER_ALLOWED_ORIGINS value %q must not contain credentials, a path, query, or fragment", raw)
+		}
+		origin := scheme + "://" + strings.ToLower(parsed.Host)
+		if _, exists := seen[origin]; exists {
+			continue
+		}
+		seen[origin] = struct{}{}
+		origins = append(origins, origin)
+	}
+	return origins, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
@@ -11,6 +12,7 @@ func TestFromEnvironmentUsesDefaults(t *testing.T) {
 	t.Setenv("ERROR_TRACER_PROJECT_ID", "")
 	t.Setenv("ERROR_TRACER_INGEST_KEY", "development-key-1")
 	t.Setenv("ERROR_TRACER_ADMIN_TOKEN", "development-admin-token-1")
+	t.Setenv("ERROR_TRACER_ALLOWED_ORIGINS", "")
 
 	cfg, err := FromEnvironment()
 	if err != nil {
@@ -36,6 +38,7 @@ func TestFromEnvironmentReadsAddress(t *testing.T) {
 	t.Setenv("ERROR_TRACER_PROJECT_ID", " project-a ")
 	t.Setenv("ERROR_TRACER_INGEST_KEY", "0123456789abcdef")
 	t.Setenv("ERROR_TRACER_ADMIN_TOKEN", " 0123456789abcdefghijklmn ")
+	t.Setenv("ERROR_TRACER_ALLOWED_ORIGINS", " HTTPS://APP.EXAMPLE.COM/ ,https://admin.example.com,https://app.example.com ")
 
 	cfg, err := FromEnvironment()
 	if err != nil {
@@ -56,6 +59,10 @@ func TestFromEnvironmentReadsAddress(t *testing.T) {
 	if cfg.AdminToken != "0123456789abcdefghijklmn" {
 		t.Fatalf("AdminToken was not loaded")
 	}
+	wantOrigins := []string{"https://app.example.com", "https://admin.example.com"}
+	if !reflect.DeepEqual(cfg.AllowedOrigins, wantOrigins) {
+		t.Fatalf("AllowedOrigins = %#v, want %#v", cfg.AllowedOrigins, wantOrigins)
+	}
 }
 
 func TestFromEnvironmentRequiresIngestKey(t *testing.T) {
@@ -73,5 +80,30 @@ func TestFromEnvironmentRequiresAdminToken(t *testing.T) {
 
 	if _, err := FromEnvironment(); err == nil {
 		t.Fatal("FromEnvironment() error = nil, want invalid admin token error")
+	}
+}
+
+func TestFromEnvironmentRejectsInvalidOrigins(t *testing.T) {
+	tests := []string{
+		"*",
+		"app.example.com",
+		"ftp://app.example.com",
+		"https://user@app.example.com",
+		"https://app.example.com/path",
+		"https://app.example.com?query=1",
+		"https://app.example.com#fragment",
+		"https://app.example.com,",
+	}
+
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv("ERROR_TRACER_INGEST_KEY", "0123456789abcdef")
+			t.Setenv("ERROR_TRACER_ADMIN_TOKEN", "0123456789abcdefghijklmn")
+			t.Setenv("ERROR_TRACER_ALLOWED_ORIGINS", value)
+
+			if _, err := FromEnvironment(); err == nil {
+				t.Fatalf("FromEnvironment() error = nil for %q", value)
+			}
+		})
 	}
 }

--- a/internal/server/origin.go
+++ b/internal/server/origin.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+)
+
+func (s *Server) ingestEventWithOrigin(w http.ResponseWriter, request *http.Request) {
+	if !s.allowEventOrigin(w, request) {
+		return
+	}
+	s.ingestEvent(w, request)
+}
+
+func (s *Server) preflightEvent(w http.ResponseWriter, request *http.Request) {
+	if !s.allowEventOrigin(w, request) {
+		return
+	}
+	if request.Header.Get("Access-Control-Request-Method") != http.MethodPost ||
+		!allowedPreflightHeaders(request.Header.Get("Access-Control-Request-Headers")) {
+		writeJSON(w, http.StatusForbidden, errorResponse{Error: "origin_not_allowed"})
+		return
+	}
+	w.Header().Set("Access-Control-Allow-Methods", http.MethodPost)
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	w.Header().Set("Access-Control-Max-Age", "600")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) allowEventOrigin(w http.ResponseWriter, request *http.Request) bool {
+	origins := request.Header.Values("Origin")
+	if len(origins) == 0 {
+		if request.Method == http.MethodOptions {
+			writeJSON(w, http.StatusForbidden, errorResponse{Error: "origin_not_allowed"})
+			return false
+		}
+		return true
+	}
+	if len(origins) != 1 {
+		writeJSON(w, http.StatusForbidden, errorResponse{Error: "origin_not_allowed"})
+		return false
+	}
+	origin := strings.ToLower(strings.TrimSpace(origins[0]))
+	if _, allowed := s.allowedOrigins[origin]; !allowed {
+		writeJSON(w, http.StatusForbidden, errorResponse{Error: "origin_not_allowed"})
+		return false
+	}
+	w.Header().Add("Vary", "Origin")
+	w.Header().Set("Access-Control-Allow-Origin", origin)
+	return true
+}
+
+func allowedPreflightHeaders(value string) bool {
+	if strings.TrimSpace(value) == "" {
+		return true
+	}
+	for _, header := range strings.Split(value, ",") {
+		if !strings.EqualFold(strings.TrimSpace(header), "Content-Type") {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/server/origin_test.go
+++ b/internal/server/origin_test.go
@@ -1,0 +1,218 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/soulteary/Error-Tracer/internal/store"
+)
+
+func TestEventOriginPolicy(t *testing.T) {
+	tests := []struct {
+		name       string
+		allowed    []string
+		origin     string
+		wantStatus int
+		wantAllow  string
+		wantVary   string
+		wantStored int
+	}{
+		{
+			name:       "trusted browser",
+			allowed:    []string{"https://app.example.com"},
+			origin:     "https://app.example.com",
+			wantStatus: http.StatusAccepted,
+			wantAllow:  "https://app.example.com",
+			wantVary:   "Origin",
+			wantStored: 1,
+		},
+		{
+			name:       "case insensitive origin",
+			allowed:    []string{"https://app.example.com"},
+			origin:     "HTTPS://APP.EXAMPLE.COM",
+			wantStatus: http.StatusAccepted,
+			wantAllow:  "https://app.example.com",
+			wantVary:   "Origin",
+			wantStored: 1,
+		},
+		{
+			name:       "untrusted browser",
+			allowed:    []string{"https://app.example.com"},
+			origin:     "https://attacker.example",
+			wantStatus: http.StatusForbidden,
+			wantStored: 0,
+		},
+		{
+			name:       "browser disabled by default",
+			origin:     "https://app.example.com",
+			wantStatus: http.StatusForbidden,
+			wantStored: 0,
+		},
+		{
+			name:       "trusted non-browser client",
+			wantStatus: http.StatusAccepted,
+			wantStored: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			memory := store.NewMemory()
+			app := New(Options{
+				Store:          memory,
+				ProjectID:      "project-a",
+				IngestKey:      "0123456789abcdef",
+				AllowedOrigins: test.allowed,
+			})
+			request := eventRequest(http.MethodPost)
+			if test.origin != "" {
+				request.Header.Set("Origin", test.origin)
+			}
+			response := httptest.NewRecorder()
+
+			app.Handler().ServeHTTP(response, request)
+
+			if response.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d; body = %s", response.Code, test.wantStatus, response.Body.String())
+			}
+			if got := response.Header().Get("Access-Control-Allow-Origin"); got != test.wantAllow {
+				t.Fatalf("Access-Control-Allow-Origin = %q, want %q", got, test.wantAllow)
+			}
+			if got := response.Header().Get("Vary"); got != test.wantVary {
+				t.Fatalf("Vary = %q, want %q", got, test.wantVary)
+			}
+			page, err := memory.ListIssues(context.Background(), "project-a", store.ListOptions{})
+			if err != nil {
+				t.Fatalf("list stored issues: %v", err)
+			}
+			if page.Total != test.wantStored {
+				t.Fatalf("stored issues = %d, want %d", page.Total, test.wantStored)
+			}
+		})
+	}
+}
+
+func TestEventOriginRejectsRepeatedHeader(t *testing.T) {
+	app := originTestServer()
+	request := eventRequest(http.MethodPost)
+	request.Header.Add("Origin", "https://app.example.com")
+	request.Header.Add("Origin", "https://app.example.com")
+	response := httptest.NewRecorder()
+
+	app.Handler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusForbidden)
+	}
+}
+
+func TestEventPreflight(t *testing.T) {
+	tests := []struct {
+		name       string
+		origin     string
+		method     string
+		headers    string
+		wantStatus int
+	}{
+		{
+			name:       "content type",
+			origin:     "https://app.example.com",
+			method:     http.MethodPost,
+			headers:    "Content-Type",
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name:       "simple header set",
+			origin:     "https://app.example.com",
+			method:     http.MethodPost,
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name:       "missing origin",
+			method:     http.MethodPost,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "untrusted origin",
+			origin:     "https://attacker.example",
+			method:     http.MethodPost,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "wrong method",
+			origin:     "https://app.example.com",
+			method:     http.MethodGet,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "credential header",
+			origin:     "https://app.example.com",
+			method:     http.MethodPost,
+			headers:    "Content-Type, Authorization",
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			app := originTestServer()
+			request := httptest.NewRequest(http.MethodOptions, "/api/v1/events", nil)
+			if test.origin != "" {
+				request.Header.Set("Origin", test.origin)
+			}
+			request.Header.Set("Access-Control-Request-Method", test.method)
+			if test.headers != "" {
+				request.Header.Set("Access-Control-Request-Headers", test.headers)
+			}
+			response := httptest.NewRecorder()
+
+			app.Handler().ServeHTTP(response, request)
+
+			if response.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d; body = %s", response.Code, test.wantStatus, response.Body.String())
+			}
+			if test.wantStatus == http.StatusNoContent {
+				if got := response.Header().Get("Access-Control-Allow-Origin"); got != test.origin {
+					t.Fatalf("Access-Control-Allow-Origin = %q, want %q", got, test.origin)
+				}
+				if got := response.Header().Get("Access-Control-Allow-Methods"); got != http.MethodPost {
+					t.Fatalf("Access-Control-Allow-Methods = %q, want POST", got)
+				}
+				if got := response.Header().Get("Access-Control-Allow-Headers"); got != "Content-Type" {
+					t.Fatalf("Access-Control-Allow-Headers = %q, want Content-Type", got)
+				}
+				if got := response.Header().Get("Access-Control-Max-Age"); got != "600" {
+					t.Fatalf("Access-Control-Max-Age = %q, want 600", got)
+				}
+			} else {
+				var result errorResponse
+				if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+					t.Fatalf("decode error response: %v", err)
+				}
+				if result.Error != "origin_not_allowed" {
+					t.Fatalf("error = %q, want origin_not_allowed", result.Error)
+				}
+			}
+		})
+	}
+}
+
+func originTestServer() *Server {
+	return New(Options{
+		Store:          store.NewMemory(),
+		ProjectID:      "project-a",
+		IngestKey:      "0123456789abcdef",
+		AllowedOrigins: []string{"https://app.example.com"},
+	})
+}
+
+func eventRequest(method string) *http.Request {
+	body := `{"project_key":"0123456789abcdef","event":{"kind":"error","message":"boom"}}`
+	request := httptest.NewRequest(method, "/api/v1/events", strings.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	return request
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,38 +11,46 @@ import (
 
 // Server owns the HTTP routes and service readiness state.
 type Server struct {
-	handler    http.Handler
-	ready      atomic.Bool
-	store      store.Store
-	projectID  string
-	ingestKey  string
-	adminToken string
-	now        func() time.Time
-	newID      func() (string, error)
+	handler        http.Handler
+	ready          atomic.Bool
+	store          store.Store
+	projectID      string
+	ingestKey      string
+	adminToken     string
+	allowedOrigins map[string]struct{}
+	now            func() time.Time
+	newID          func() (string, error)
 }
 
 // Options provides the dependencies required by the HTTP service.
 type Options struct {
-	Store      store.Store
-	ProjectID  string
-	IngestKey  string
-	AdminToken string
+	Store          store.Store
+	ProjectID      string
+	IngestKey      string
+	AdminToken     string
+	AllowedOrigins []string
 }
 
 // New creates a service with liveness and readiness endpoints.
 func New(options Options) *Server {
+	allowedOrigins := make(map[string]struct{}, len(options.AllowedOrigins))
+	for _, origin := range options.AllowedOrigins {
+		allowedOrigins[origin] = struct{}{}
+	}
 	server := &Server{
-		store:      options.Store,
-		projectID:  options.ProjectID,
-		ingestKey:  options.IngestKey,
-		adminToken: options.AdminToken,
-		now:        time.Now,
-		newID:      randomEventID,
+		store:          options.Store,
+		projectID:      options.ProjectID,
+		ingestKey:      options.IngestKey,
+		adminToken:     options.AdminToken,
+		allowedOrigins: allowedOrigins,
+		now:            time.Now,
+		newID:          randomEventID,
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", server.health)
 	mux.HandleFunc("GET /readyz", server.readiness)
-	mux.HandleFunc("POST /api/v1/events", server.ingestEvent)
+	mux.HandleFunc("POST /api/v1/events", server.ingestEventWithOrigin)
+	mux.HandleFunc("OPTIONS /api/v1/events", server.preflightEvent)
 	mux.HandleFunc("GET /api/v1/issues", server.listIssues)
 	mux.HandleFunc("GET /api/v1/issues/{fingerprint}", server.getIssue)
 	mux.HandleFunc("PATCH /api/v1/issues/{fingerprint}", server.updateIssue)


### PR DESCRIPTION
## Summary

- load a comma-separated `ERROR_TRACER_ALLOWED_ORIGINS` setting
- canonicalize scheme and host casing and remove duplicate origins
- reject wildcard, non-HTTP, credential-bearing, path, query, and fragment values at startup
- enforce the exact allowlist for browser event submissions
- add a bounded CORS preflight that permits only `POST` and `Content-Type`
- continue accepting requests without an `Origin` header for trusted non-browser clients

## Security behavior

An empty allowlist disables browser-origin ingestion. It does not treat the browser-visible ingest key as a secret or silently allow every origin.

Repeated or unrecognized `Origin` headers are rejected. No credentialed CORS mode is enabled.

## Scope

This PR adds only origin parsing and ingestion CORS policy. Rate limiting, SDK behavior, and dashboard assets remain separate PRs.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`

The branch is one commit ahead of `master` and changes only the six origin-policy files.