### PR TITLE
Rate limit event ingestion

### DIFF
--- a/cmd/error-tracer/main.go
+++ b/cmd/error-tracer/main.go
@@ -38,6 +38,8 @@ func main() {
 		IngestKey:      cfg.IngestKey,
 		AdminToken:     cfg.AdminToken,
 		AllowedOrigins: cfg.AllowedOrigins,
+		RatePerMinute:  cfg.RatePerMinute,
+		RateBurst:      cfg.RateBurst,
 	})
 
 	httpServer := &http.Server{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -12,6 +13,8 @@ import (
 const (
 	defaultAddress         = ":8080"
 	defaultDatabasePath    = "error-tracer.db"
+	defaultRatePerMinute   = 120
+	defaultRateBurst       = 30
 	defaultShutdownTimeout = 10 * time.Second
 )
 
@@ -24,6 +27,8 @@ type Config struct {
 	IngestKey       string
 	AdminToken      string
 	AllowedOrigins  []string
+	RatePerMinute   int
+	RateBurst       int
 }
 
 // FromEnvironment loads configuration without mutating process state.
@@ -52,6 +57,14 @@ func FromEnvironment() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	ratePerMinute, err := positiveInteger("ERROR_TRACER_RATE_PER_MINUTE", defaultRatePerMinute, 60_000)
+	if err != nil {
+		return Config{}, err
+	}
+	rateBurst, err := positiveInteger("ERROR_TRACER_RATE_BURST", defaultRateBurst, 10_000)
+	if err != nil {
+		return Config{}, err
+	}
 
 	return Config{
 		Address:         address,
@@ -61,7 +74,21 @@ func FromEnvironment() (Config, error) {
 		IngestKey:       ingestKey,
 		AdminToken:      adminToken,
 		AllowedOrigins:  allowedOrigins,
+		RatePerMinute:   ratePerMinute,
+		RateBurst:       rateBurst,
 	}, nil
+}
+
+func positiveInteger(name string, fallback, maximum int) (int, error) {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return fallback, nil
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < 1 || value > maximum {
+		return 0, fmt.Errorf("%s must be an integer between 1 and %d", name, maximum)
+	}
+	return value, nil
 }
 
 func parseOrigins(value string) ([]string, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,6 +13,8 @@ func TestFromEnvironmentUsesDefaults(t *testing.T) {
 	t.Setenv("ERROR_TRACER_INGEST_KEY", "development-key-1")
 	t.Setenv("ERROR_TRACER_ADMIN_TOKEN", "development-admin-token-1")
 	t.Setenv("ERROR_TRACER_ALLOWED_ORIGINS", "")
+	t.Setenv("ERROR_TRACER_RATE_PER_MINUTE", "")
+	t.Setenv("ERROR_TRACER_RATE_BURST", "")
 
 	cfg, err := FromEnvironment()
 	if err != nil {
@@ -30,6 +32,9 @@ func TestFromEnvironmentUsesDefaults(t *testing.T) {
 	if cfg.ProjectID != "default" {
 		t.Fatalf("ProjectID = %q, want %q", cfg.ProjectID, "default")
 	}
+	if cfg.RatePerMinute != 120 || cfg.RateBurst != 30 {
+		t.Fatalf("rate = %d/minute burst %d, want 120/minute burst 30", cfg.RatePerMinute, cfg.RateBurst)
+	}
 }
 
 func TestFromEnvironmentReadsAddress(t *testing.T) {
@@ -39,6 +44,8 @@ func TestFromEnvironmentReadsAddress(t *testing.T) {
 	t.Setenv("ERROR_TRACER_INGEST_KEY", "0123456789abcdef")
 	t.Setenv("ERROR_TRACER_ADMIN_TOKEN", " 0123456789abcdefghijklmn ")
 	t.Setenv("ERROR_TRACER_ALLOWED_ORIGINS", " HTTPS://APP.EXAMPLE.COM/ ,https://admin.example.com,https://app.example.com ")
+	t.Setenv("ERROR_TRACER_RATE_PER_MINUTE", " 240 ")
+	t.Setenv("ERROR_TRACER_RATE_BURST", " 40 ")
 
 	cfg, err := FromEnvironment()
 	if err != nil {
@@ -62,6 +69,9 @@ func TestFromEnvironmentReadsAddress(t *testing.T) {
 	wantOrigins := []string{"https://app.example.com", "https://admin.example.com"}
 	if !reflect.DeepEqual(cfg.AllowedOrigins, wantOrigins) {
 		t.Fatalf("AllowedOrigins = %#v, want %#v", cfg.AllowedOrigins, wantOrigins)
+	}
+	if cfg.RatePerMinute != 240 || cfg.RateBurst != 40 {
+		t.Fatalf("rate = %d/minute burst %d, want 240/minute burst 40", cfg.RatePerMinute, cfg.RateBurst)
 	}
 }
 
@@ -103,6 +113,37 @@ func TestFromEnvironmentRejectsInvalidOrigins(t *testing.T) {
 
 			if _, err := FromEnvironment(); err == nil {
 				t.Fatalf("FromEnvironment() error = nil for %q", value)
+			}
+		})
+	}
+}
+
+func TestFromEnvironmentRejectsInvalidRateLimits(t *testing.T) {
+	tests := []struct {
+		name     string
+		variable string
+		value    string
+	}{
+		{name: "rate zero", variable: "ERROR_TRACER_RATE_PER_MINUTE", value: "0"},
+		{name: "rate negative", variable: "ERROR_TRACER_RATE_PER_MINUTE", value: "-1"},
+		{name: "rate text", variable: "ERROR_TRACER_RATE_PER_MINUTE", value: "many"},
+		{name: "rate too large", variable: "ERROR_TRACER_RATE_PER_MINUTE", value: "60001"},
+		{name: "burst zero", variable: "ERROR_TRACER_RATE_BURST", value: "0"},
+		{name: "burst negative", variable: "ERROR_TRACER_RATE_BURST", value: "-1"},
+		{name: "burst too large", variable: "ERROR_TRACER_RATE_BURST", value: "10001"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("ERROR_TRACER_INGEST_KEY", "0123456789abcdef")
+			t.Setenv("ERROR_TRACER_ADMIN_TOKEN", "0123456789abcdefghijklmn")
+			t.Setenv("ERROR_TRACER_ALLOWED_ORIGINS", "")
+			t.Setenv("ERROR_TRACER_RATE_PER_MINUTE", "")
+			t.Setenv("ERROR_TRACER_RATE_BURST", "")
+			t.Setenv(test.variable, test.value)
+
+			if _, err := FromEnvironment(); err == nil {
+				t.Fatalf("FromEnvironment() error = nil for %s=%q", test.variable, test.value)
 			}
 		})
 	}

--- a/internal/server/origin.go
+++ b/internal/server/origin.go
@@ -9,6 +9,12 @@ func (s *Server) ingestEventWithOrigin(w http.ResponseWriter, request *http.Requ
 	if !s.allowEventOrigin(w, request) {
 		return
 	}
+	allowed, retryAfter := s.ingestLimiter.Allow(clientAddress(request.RemoteAddr))
+	if !allowed {
+		w.Header().Set("Retry-After", retryAfterHeader(retryAfter))
+		writeJSON(w, http.StatusTooManyRequests, errorResponse{Error: "rate_limited"})
+		return
+	}
 	s.ingestEvent(w, request)
 }
 

--- a/internal/server/ratelimit.go
+++ b/internal/server/ratelimit.go
@@ -1,0 +1,107 @@
+package server
+
+import (
+	"math"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultRatePerMinute = 120
+	defaultRateBurst     = 30
+	maxRateLimitClients  = 10_000
+	rateLimitClientTTL   = 10 * time.Minute
+)
+
+type rateBucket struct {
+	tokens   float64
+	updated  time.Time
+	lastSeen time.Time
+}
+
+type rateLimiter struct {
+	mu            sync.Mutex
+	buckets       map[string]rateBucket
+	perSecond     float64
+	burst         float64
+	maxClients    int
+	now           func() time.Time
+	lastSweepTime time.Time
+}
+
+func newRateLimiter(perMinute, burst int) *rateLimiter {
+	if perMinute <= 0 {
+		perMinute = defaultRatePerMinute
+	}
+	if burst <= 0 {
+		burst = defaultRateBurst
+	}
+	return &rateLimiter{
+		buckets:    make(map[string]rateBucket),
+		perSecond:  float64(perMinute) / 60,
+		burst:      float64(burst),
+		maxClients: maxRateLimitClients,
+		now:        time.Now,
+	}
+}
+
+// Allow consumes one token for a client or returns the time until one is
+// available. The map is bounded so unique-source floods cannot grow memory
+// without limit.
+func (limiter *rateLimiter) Allow(client string) (bool, time.Duration) {
+	now := limiter.now()
+	limiter.mu.Lock()
+	defer limiter.mu.Unlock()
+
+	if limiter.lastSweepTime.IsZero() || now.Sub(limiter.lastSweepTime) >= time.Minute {
+		for key, bucket := range limiter.buckets {
+			if now.Sub(bucket.lastSeen) >= rateLimitClientTTL {
+				delete(limiter.buckets, key)
+			}
+		}
+		limiter.lastSweepTime = now
+	}
+
+	bucket, exists := limiter.buckets[client]
+	if !exists {
+		if len(limiter.buckets) >= limiter.maxClients {
+			return false, time.Minute
+		}
+		bucket = rateBucket{tokens: limiter.burst, updated: now, lastSeen: now}
+	}
+	if elapsed := now.Sub(bucket.updated).Seconds(); elapsed > 0 {
+		bucket.tokens = min(limiter.burst, bucket.tokens+elapsed*limiter.perSecond)
+		bucket.updated = now
+	}
+	bucket.lastSeen = now
+	if bucket.tokens >= 1 {
+		bucket.tokens--
+		limiter.buckets[client] = bucket
+		return true, 0
+	}
+	limiter.buckets[client] = bucket
+	retrySeconds := (1 - bucket.tokens) / limiter.perSecond
+	return false, time.Duration(math.Ceil(retrySeconds * float64(time.Second)))
+}
+
+func clientAddress(remoteAddress string) string {
+	remoteAddress = strings.TrimSpace(remoteAddress)
+	host, _, err := net.SplitHostPort(remoteAddress)
+	if err == nil {
+		if address := net.ParseIP(host); address != nil {
+			return address.String()
+		}
+	}
+	if address := net.ParseIP(remoteAddress); address != nil {
+		return address.String()
+	}
+	return "unknown"
+}
+
+func retryAfterHeader(retryAfter time.Duration) string {
+	seconds := int64(math.Ceil(retryAfter.Seconds()))
+	return strconv.FormatInt(max(seconds, 1), 10)
+}

--- a/internal/server/ratelimit_test.go
+++ b/internal/server/ratelimit_test.go
@@ -1,0 +1,205 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/soulteary/Error-Tracer/internal/store"
+)
+
+func TestRateLimiterRefillsAndCapsTokens(t *testing.T) {
+	now := time.Date(2026, time.August, 29, 3, 0, 0, 0, time.UTC)
+	limiter := newRateLimiter(60, 2)
+	limiter.now = func() time.Time { return now }
+
+	if allowed, _ := limiter.Allow("client"); !allowed {
+		t.Fatal("first event was rejected")
+	}
+	if allowed, _ := limiter.Allow("client"); !allowed {
+		t.Fatal("second event was rejected")
+	}
+	if allowed, retryAfter := limiter.Allow("client"); allowed || retryAfter != time.Second {
+		t.Fatalf("third event = (%v, %s), want rejected for 1s", allowed, retryAfter)
+	}
+
+	now = now.Add(500 * time.Millisecond)
+	if allowed, retryAfter := limiter.Allow("client"); allowed || retryAfter != 500*time.Millisecond {
+		t.Fatalf("half-refilled event = (%v, %s), want rejected for 500ms", allowed, retryAfter)
+	}
+	now = now.Add(500 * time.Millisecond)
+	if allowed, _ := limiter.Allow("client"); !allowed {
+		t.Fatal("refilled event was rejected")
+	}
+
+	now = now.Add(10 * time.Second)
+	if allowed, _ := limiter.Allow("client"); !allowed {
+		t.Fatal("first capped event was rejected")
+	}
+	if allowed, _ := limiter.Allow("client"); !allowed {
+		t.Fatal("second capped event was rejected")
+	}
+	if allowed, _ := limiter.Allow("client"); allowed {
+		t.Fatal("bucket exceeded its configured burst")
+	}
+}
+
+func TestRateLimiterSeparatesClients(t *testing.T) {
+	limiter := newRateLimiter(60, 1)
+	now := time.Date(2026, time.August, 29, 3, 0, 0, 0, time.UTC)
+	limiter.now = func() time.Time { return now }
+
+	if allowed, _ := limiter.Allow("client-a"); !allowed {
+		t.Fatal("client-a first event was rejected")
+	}
+	if allowed, _ := limiter.Allow("client-a"); allowed {
+		t.Fatal("client-a exceeded its burst")
+	}
+	if allowed, _ := limiter.Allow("client-b"); !allowed {
+		t.Fatal("client-b was affected by client-a")
+	}
+}
+
+func TestRateLimiterBoundsAndExpiresClientBuckets(t *testing.T) {
+	now := time.Date(2026, time.August, 29, 3, 0, 0, 0, time.UTC)
+	limiter := newRateLimiter(60, 1)
+	limiter.maxClients = 2
+	limiter.now = func() time.Time { return now }
+
+	limiter.Allow("client-a")
+	limiter.Allow("client-b")
+	if allowed, retryAfter := limiter.Allow("client-c"); allowed || retryAfter != time.Minute {
+		t.Fatalf("overflow client = (%v, %s), want rejected for 1m", allowed, retryAfter)
+	}
+	if len(limiter.buckets) != 2 {
+		t.Fatalf("buckets = %d, want bounded at 2", len(limiter.buckets))
+	}
+
+	now = now.Add(rateLimitClientTTL)
+	if allowed, _ := limiter.Allow("client-c"); !allowed {
+		t.Fatal("expired buckets were not reclaimed")
+	}
+	if len(limiter.buckets) != 1 {
+		t.Fatalf("buckets after sweep = %d, want 1", len(limiter.buckets))
+	}
+}
+
+func TestClientAddressUsesOnlyDirectPeer(t *testing.T) {
+	tests := map[string]string{
+		"192.0.2.10:4321":     "192.0.2.10",
+		"192.0.2.10":          "192.0.2.10",
+		"[2001:db8::1]:4321":  "2001:db8::1",
+		"2001:db8::1":         "2001:db8::1",
+		"proxy.example:4321":  "unknown",
+		"malformed forwarded": "unknown",
+		"":                    "unknown",
+	}
+
+	for input, want := range tests {
+		if got := clientAddress(input); got != want {
+			t.Errorf("clientAddress(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestRetryAfterHeaderRoundsUp(t *testing.T) {
+	tests := map[time.Duration]string{
+		0:                      "1",
+		100 * time.Millisecond: "1",
+		time.Second:            "1",
+		time.Second + 1:        "2",
+	}
+	for input, want := range tests {
+		if got := retryAfterHeader(input); got != want {
+			t.Errorf("retryAfterHeader(%s) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestIngestRateLimitUsesRemoteAddress(t *testing.T) {
+	memory := store.NewMemory()
+	app := New(Options{
+		Store:         memory,
+		ProjectID:     "project-a",
+		IngestKey:     "0123456789abcdef",
+		RatePerMinute: 60,
+		RateBurst:     1,
+	})
+
+	first := eventRequest(http.MethodPost)
+	first.RemoteAddr = "192.0.2.10:1000"
+	first.Header.Set("X-Forwarded-For", "198.51.100.1")
+	firstResponse := httptest.NewRecorder()
+	app.Handler().ServeHTTP(firstResponse, first)
+	if firstResponse.Code != http.StatusAccepted {
+		t.Fatalf("first status = %d, want %d", firstResponse.Code, http.StatusAccepted)
+	}
+
+	second := eventRequest(http.MethodPost)
+	second.RemoteAddr = "192.0.2.10:2000"
+	second.Header.Set("X-Forwarded-For", "203.0.113.200")
+	secondResponse := httptest.NewRecorder()
+	app.Handler().ServeHTTP(secondResponse, second)
+	if secondResponse.Code != http.StatusTooManyRequests {
+		t.Fatalf("second status = %d, want %d; body = %s", secondResponse.Code, http.StatusTooManyRequests, secondResponse.Body.String())
+	}
+	if got := secondResponse.Header().Get("Retry-After"); got != "1" {
+		t.Fatalf("Retry-After = %q, want 1", got)
+	}
+	var failure errorResponse
+	if err := json.NewDecoder(secondResponse.Body).Decode(&failure); err != nil {
+		t.Fatalf("decode rate-limit response: %v", err)
+	}
+	if failure.Error != "rate_limited" {
+		t.Fatalf("error = %q, want rate_limited", failure.Error)
+	}
+
+	third := eventRequest(http.MethodPost)
+	third.RemoteAddr = "192.0.2.11:1000"
+	thirdResponse := httptest.NewRecorder()
+	app.Handler().ServeHTTP(thirdResponse, third)
+	if thirdResponse.Code != http.StatusAccepted {
+		t.Fatalf("different peer status = %d, want %d", thirdResponse.Code, http.StatusAccepted)
+	}
+
+	page, err := memory.ListIssues(context.Background(), "project-a", store.ListOptions{})
+	if err != nil {
+		t.Fatalf("list issues: %v", err)
+	}
+	if page.Total != 1 || page.Issues[0].Occurrences != 2 {
+		t.Fatalf("stored page = %#v, want one issue with two accepted events", page)
+	}
+}
+
+func TestPreflightDoesNotConsumeIngestBudget(t *testing.T) {
+	app := New(Options{
+		Store:          store.NewMemory(),
+		ProjectID:      "project-a",
+		IngestKey:      "0123456789abcdef",
+		AllowedOrigins: []string{"https://app.example.com"},
+		RatePerMinute:  60,
+		RateBurst:      1,
+	})
+
+	preflight := httptest.NewRequest(http.MethodOptions, "/api/v1/events", nil)
+	preflight.RemoteAddr = "192.0.2.10:1000"
+	preflight.Header.Set("Origin", "https://app.example.com")
+	preflight.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	preflightResponse := httptest.NewRecorder()
+	app.Handler().ServeHTTP(preflightResponse, preflight)
+	if preflightResponse.Code != http.StatusNoContent {
+		t.Fatalf("preflight status = %d, want %d", preflightResponse.Code, http.StatusNoContent)
+	}
+
+	submission := eventRequest(http.MethodPost)
+	submission.RemoteAddr = "192.0.2.10:2000"
+	submission.Header.Set("Origin", "https://app.example.com")
+	submissionResponse := httptest.NewRecorder()
+	app.Handler().ServeHTTP(submissionResponse, submission)
+	if submissionResponse.Code != http.StatusAccepted {
+		t.Fatalf("submission status = %d, want %d", submissionResponse.Code, http.StatusAccepted)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,6 +18,7 @@ type Server struct {
 	ingestKey      string
 	adminToken     string
 	allowedOrigins map[string]struct{}
+	ingestLimiter  *rateLimiter
 	now            func() time.Time
 	newID          func() (string, error)
 }
@@ -29,6 +30,8 @@ type Options struct {
 	IngestKey      string
 	AdminToken     string
 	AllowedOrigins []string
+	RatePerMinute  int
+	RateBurst      int
 }
 
 // New creates a service with liveness and readiness endpoints.
@@ -43,6 +46,7 @@ func New(options Options) *Server {
 		ingestKey:      options.IngestKey,
 		adminToken:     options.AdminToken,
 		allowedOrigins: allowedOrigins,
+		ingestLimiter:  newRateLimiter(options.RatePerMinute, options.RateBurst),
 		now:            time.Now,
 		newID:          randomEventID,
 	}


### PR DESCRIPTION
## Summary

- add a per-client token-bucket limiter to event submissions
- configure refill and burst limits with bounded environment variables
- return `429 Too Many Requests` and a rounded `Retry-After` header
- key clients from the direct network peer instead of spoofable forwarded-address headers
- cap the in-memory client map at 10,000 entries
- expire inactive client buckets after 10 minutes
- leave CORS preflights outside the event budget

## Defaults

- `ERROR_TRACER_RATE_PER_MINUTE=120`
- `ERROR_TRACER_RATE_BURST=30`

The startup parser accepts only positive integers, with explicit upper bounds of 60,000 and 10,000 respectively.

## Scope

This PR adds only ingestion rate limiting and its configuration. Browser-side sampling, SDK delivery, and reverse-proxy trust configuration remain separate concerns.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`

The branch is one commit ahead of `master` and changes only the seven rate-limit files.