### PR TITLE
Add the browser SDK core

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "error-tracer",
+  "version": "2.0.0-dev",
+  "private": true,
+  "description": "A small self-hosted browser error collector",
+  "license": "Apache-2.0",
+  "type": "commonjs",
+  "scripts": {
+    "test": "node --test sdk/*.test.js"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/sdk/error-tracer.js
+++ b/sdk/error-tracer.js
@@ -1,0 +1,415 @@
+// SPDX-License-Identifier: Apache-2.0
+
+(function exposeErrorTracer(root, factory) {
+  const api = factory(root);
+  if (typeof module === "object" && module.exports) {
+    module.exports = api;
+  } else {
+    root.ErrorTracer = api;
+  }
+})(typeof globalThis === "object" ? globalThis : this, function createAPI(defaultRuntime) {
+  "use strict";
+
+  const LIMITS = Object.freeze({
+    message: 4 * 1024,
+    stack: 64 * 1024,
+    url: 2 * 1024,
+    release: 128,
+    environment: 128,
+    tagCount: 32,
+    tagKey: 64,
+    tagValue: 256,
+  });
+  const EVENT_KINDS = new Set(["error", "unhandled_rejection", "resource_error"]);
+
+  class Client {
+    constructor(options) {
+      options = options || {};
+      if (typeof options !== "object") {
+        throw new TypeError("ErrorTracer options must be an object");
+      }
+
+      this.runtime = options.runtime || defaultRuntime;
+      this.endpoint = cleanString(options.endpoint || "/api/v1/events");
+      this.projectKey = cleanString(options.projectKey);
+      if (!this.endpoint) {
+        throw new TypeError("ErrorTracer endpoint is required");
+      }
+      if (utf8Length(this.projectKey) < 16) {
+        throw new TypeError("ErrorTracer projectKey must contain at least 16 bytes");
+      }
+
+      this.sampleRate = options.sampleRate === undefined ? 1 : Number(options.sampleRate);
+      if (!Number.isFinite(this.sampleRate) || this.sampleRate < 0 || this.sampleRate > 1) {
+        throw new TypeError("ErrorTracer sampleRate must be between 0 and 1");
+      }
+      this.maxEventsPerMinute = options.maxEventsPerMinute === undefined
+        ? 30
+        : Number(options.maxEventsPerMinute);
+      if (!Number.isInteger(this.maxEventsPerMinute) ||
+          this.maxEventsPerMinute < 1 ||
+          this.maxEventsPerMinute > 1000) {
+        throw new TypeError("ErrorTracer maxEventsPerMinute must be an integer between 1 and 1000");
+      }
+      if (options.beforeSend !== undefined && typeof options.beforeSend !== "function") {
+        throw new TypeError("ErrorTracer beforeSend must be a function");
+      }
+      if (options.transport !== undefined && typeof options.transport !== "function") {
+        throw new TypeError("ErrorTracer transport must be a function");
+      }
+
+      this.release = truncateUTF8(cleanString(options.release), LIMITS.release);
+      this.environment = truncateUTF8(cleanString(options.environment), LIMITS.environment);
+      this.tags = normalizeTags(options.tags);
+      this.beforeSend = options.beforeSend || null;
+      this.random = typeof options.random === "function" ? options.random : Math.random;
+      this.clock = typeof options.clock === "function" ? options.clock : () => new Date();
+      this.sentAt = [];
+      this.transport = options.transport || defaultTransport(this.runtime, this.endpoint);
+    }
+
+    captureException(error, context) {
+      context = context || {};
+      const details = errorDetails(error);
+      return this.capture({
+        kind: "error",
+        message: details.message,
+        stack: details.stack,
+        source_url: safeRead(context, "sourceURL"),
+        line: safeRead(context, "line"),
+        column: safeRead(context, "column"),
+        tags: safeRead(context, "tags"),
+      });
+    }
+
+    captureMessage(message, context) {
+      context = context || {};
+      return this.capture({
+        kind: "error",
+        message,
+        source_url: safeRead(context, "sourceURL"),
+        line: safeRead(context, "line"),
+        column: safeRead(context, "column"),
+        tags: safeRead(context, "tags"),
+      });
+    }
+
+    capture(candidate) {
+      if (this.sampleRate === 0) {
+        return Promise.resolve(false);
+      }
+      let randomValue;
+      try {
+        randomValue = this.random();
+      } catch (_) {
+        return Promise.resolve(false);
+      }
+      if (!Number.isFinite(randomValue) || randomValue < 0 || randomValue >= this.sampleRate) {
+        return Promise.resolve(false);
+      }
+
+      let captured;
+      try {
+        captured = this.normalize(candidate);
+      } catch (_) {
+        return Promise.resolve(false);
+      }
+      if (!captured) {
+        return Promise.resolve(false);
+      }
+      if (this.beforeSend) {
+        try {
+          captured = this.beforeSend(cloneEvent(captured));
+        } catch (_) {
+          return Promise.resolve(false);
+        }
+        if (captured === null || captured === false) {
+          return Promise.resolve(false);
+        }
+        try {
+          captured = this.normalize(captured);
+        } catch (_) {
+          return Promise.resolve(false);
+        }
+        if (!captured) {
+          return Promise.resolve(false);
+        }
+      }
+
+      let now;
+      try {
+        now = validDate(this.clock());
+      } catch (_) {
+        return Promise.resolve(false);
+      }
+      if (!this.consumeBudget(now.getTime())) {
+        return Promise.resolve(false);
+      }
+      captured.occurred_at = validISODate(captured.occurred_at) || now.toISOString();
+
+      const payload = { project_key: this.projectKey, event: captured };
+      const body = JSON.stringify(payload);
+      try {
+        return Promise.resolve(this.transport(body, payload))
+          .then((result) => result !== false)
+          .catch(() => false);
+      } catch (_) {
+        return Promise.resolve(false);
+      }
+    }
+
+    normalize(candidate) {
+      if (!candidate || typeof candidate !== "object") {
+        return null;
+      }
+      const candidateKind = cleanString(safeRead(candidate, "kind"));
+      const kind = EVENT_KINDS.has(candidateKind) ? candidateKind : "error";
+      const message = truncateUTF8(cleanString(safeRead(candidate, "message")), LIMITS.message);
+      const sourceURL = truncateUTF8(
+        scrubURL(safeRead(candidate, "source_url"), this.runtime),
+        LIMITS.url,
+      );
+      if (kind === "resource_error" && !sourceURL) {
+        return null;
+      }
+      if (kind !== "resource_error" && !message) {
+        return null;
+      }
+
+      const pageURL = truncateUTF8(
+        scrubURL(safeRead(candidate, "page_url") || readLocation(this.runtime), this.runtime),
+        LIMITS.url,
+      );
+      return compactObject({
+        kind,
+        message,
+        stack: truncateUTF8(cleanString(safeRead(candidate, "stack")), LIMITS.stack),
+        source_url: sourceURL,
+        page_url: pageURL,
+        line: nonNegativeInteger(safeRead(candidate, "line")),
+        column: nonNegativeInteger(safeRead(candidate, "column")),
+        occurred_at: validISODate(safeRead(candidate, "occurred_at")),
+        release: truncateUTF8(
+          cleanString(safeRead(candidate, "release") || this.release),
+          LIMITS.release,
+        ),
+        environment: truncateUTF8(
+          cleanString(safeRead(candidate, "environment") || this.environment),
+          LIMITS.environment,
+        ),
+        tags: normalizeTags(mergeTags(this.tags, safeRead(candidate, "tags"))),
+      });
+    }
+
+    consumeBudget(now) {
+      const cutoff = now - 60_000;
+      while (this.sentAt.length && this.sentAt[0] <= cutoff) {
+        this.sentAt.shift();
+      }
+      if (this.sentAt.length >= this.maxEventsPerMinute) {
+        return false;
+      }
+      this.sentAt.push(now);
+      return true;
+    }
+  }
+
+  function defaultTransport(runtime, endpoint) {
+    return function send(body) {
+      const navigator = safeRead(runtime, "navigator");
+      const BlobConstructor = safeRead(runtime, "Blob");
+      const sendBeacon = safeRead(navigator, "sendBeacon");
+      if (typeof sendBeacon === "function" && typeof BlobConstructor === "function") {
+        try {
+          const blob = new BlobConstructor([body], { type: "text/plain;charset=UTF-8" });
+          if (sendBeacon.call(navigator, endpoint, blob)) {
+            return true;
+          }
+        } catch (_) {
+          // Fall through to fetch when Beacon is unavailable or rejected.
+        }
+      }
+
+      const fetchFunction = safeRead(runtime, "fetch");
+      if (typeof fetchFunction !== "function") {
+        return false;
+      }
+      return fetchFunction.call(runtime, endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+        credentials: "omit",
+        keepalive: true,
+      }).then((response) => Boolean(response && response.ok));
+    };
+  }
+
+  function errorDetails(error) {
+    const message = cleanString(safeRead(error, "message")) || safeString(error) || "Unknown error";
+    return {
+      message,
+      stack: cleanString(safeRead(error, "stack")),
+    };
+  }
+
+  function normalizeTags(input) {
+    if (!input || typeof input !== "object") {
+      return undefined;
+    }
+    const tags = {};
+    let count = 0;
+    for (const [rawKey, rawValue] of safeEntries(input)) {
+      if (count >= LIMITS.tagCount) {
+        break;
+      }
+      const key = truncateUTF8(cleanString(rawKey), LIMITS.tagKey);
+      if (!key || key === "__proto__" || key === "prototype" || key === "constructor") {
+        continue;
+      }
+      tags[key] = truncateUTF8(cleanString(rawValue), LIMITS.tagValue);
+      count++;
+    }
+    return count ? tags : undefined;
+  }
+
+  function mergeTags(...sources) {
+    const merged = Object.create(null);
+    for (const source of sources) {
+      for (const [key, value] of safeEntries(source)) {
+        merged[key] = value;
+      }
+    }
+    return merged;
+  }
+
+  function safeEntries(value) {
+    try {
+      return value && typeof value === "object" ? Object.entries(value) : [];
+    } catch (_) {
+      return [];
+    }
+  }
+
+  function scrubURL(value, runtime) {
+    value = cleanString(value);
+    if (!value) {
+      return "";
+    }
+    try {
+      const RuntimeURL = safeRead(runtime, "URL") ||
+        (typeof URL === "function" ? URL : null);
+      if (!RuntimeURL) {
+        throw new Error("URL is unavailable");
+      }
+      const base = readLocation(runtime) || undefined;
+      const parsed = base ? new RuntimeURL(value, base) : new RuntimeURL(value);
+      parsed.username = "";
+      parsed.password = "";
+      parsed.search = "";
+      parsed.hash = "";
+      return parsed.toString();
+    } catch (_) {
+      return value.split("#", 1)[0].split("?", 1)[0];
+    }
+  }
+
+  function readLocation(runtime) {
+    try {
+      const location = safeRead(runtime, "location");
+      return location ? cleanString(safeRead(location, "href")) : "";
+    } catch (_) {
+      return "";
+    }
+  }
+
+  function safeRead(value, property) {
+    try {
+      return value && value[property];
+    } catch (_) {
+      return "";
+    }
+  }
+
+  function safeString(value) {
+    try {
+      return value === undefined || value === null ? "" : String(value);
+    } catch (_) {
+      return "";
+    }
+  }
+
+  function cleanString(value) {
+    return safeString(value).trim();
+  }
+
+  function utf8Length(value) {
+    let bytes = 0;
+    for (const character of safeString(value)) {
+      const point = character.codePointAt(0);
+      bytes += point <= 0x7f ? 1 : point <= 0x7ff ? 2 : point <= 0xffff ? 3 : 4;
+    }
+    return bytes;
+  }
+
+  function truncateUTF8(value, maximum) {
+    value = safeString(value);
+    let bytes = 0;
+    const characters = [];
+    for (const character of value) {
+      const point = character.codePointAt(0);
+      const size = point <= 0x7f ? 1 : point <= 0x7ff ? 2 : point <= 0xffff ? 3 : 4;
+      if (bytes + size > maximum) {
+        break;
+      }
+      characters.push(character);
+      bytes += size;
+    }
+    return characters.join("");
+  }
+
+  function nonNegativeInteger(value) {
+    value = Number(value);
+    return Number.isInteger(value) && value > 0 ? value : undefined;
+  }
+
+  function validISODate(value) {
+    if (!value) {
+      return undefined;
+    }
+    try {
+      const date = new Date(value);
+      return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+    } catch (_) {
+      return undefined;
+    }
+  }
+
+  function validDate(value) {
+    try {
+      const date = value instanceof Date ? value : new Date(value);
+      return Number.isNaN(date.getTime()) ? new Date() : date;
+    } catch (_) {
+      return new Date();
+    }
+  }
+
+  function compactObject(value) {
+    for (const key of Object.keys(value)) {
+      if (value[key] === undefined || value[key] === "") {
+        delete value[key];
+      }
+    }
+    return value;
+  }
+
+  function cloneEvent(value) {
+    return Object.assign({}, value, value.tags ? { tags: Object.assign({}, value.tags) } : {});
+  }
+
+  return Object.freeze({
+    Client,
+    init(options) {
+      return new Client(options);
+    },
+  });
+});

--- a/sdk/error-tracer.test.js
+++ b/sdk/error-tracer.test.js
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: Apache-2.0
+
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const ErrorTracer = require("./error-tracer.js");
+
+const PROJECT_KEY = "0123456789abcdef";
+const FIXED_TIME = new Date("2026-08-29T03:00:00.000Z");
+
+test("validates client options", () => {
+  assert.throws(() => ErrorTracer.init(), /projectKey/);
+  assert.throws(() => ErrorTracer.init("invalid"), /options/);
+  assert.throws(() => ErrorTracer.init({ projectKey: "short" }), /projectKey/);
+  assert.throws(() => ErrorTracer.init({ projectKey: "界".repeat(5) }), /projectKey/);
+  assert.throws(() => ErrorTracer.init({ projectKey: PROJECT_KEY, endpoint: " " }), /endpoint/);
+  assert.throws(() => ErrorTracer.init({ projectKey: PROJECT_KEY, sampleRate: -0.1 }), /sampleRate/);
+  assert.throws(() => ErrorTracer.init({ projectKey: PROJECT_KEY, sampleRate: 1.1 }), /sampleRate/);
+  assert.throws(() => ErrorTracer.init({ projectKey: PROJECT_KEY, maxEventsPerMinute: 0 }), /maxEventsPerMinute/);
+  assert.throws(() => ErrorTracer.init({ projectKey: PROJECT_KEY, maxEventsPerMinute: 1001 }), /maxEventsPerMinute/);
+  assert.throws(() => ErrorTracer.init({ projectKey: PROJECT_KEY, beforeSend: true }), /beforeSend/);
+  assert.throws(() => ErrorTracer.init({ projectKey: PROJECT_KEY, transport: true }), /transport/);
+
+  assert.ok(ErrorTracer.init({
+    projectKey: "界".repeat(6),
+    transport() {
+      return true;
+    },
+  }) instanceof ErrorTracer.Client);
+});
+
+test("captures and normalizes an exception", async () => {
+  let body;
+  let payload;
+  const runtime = {
+    location: {
+      href: "https://user:password@app.example/checkout?token=secret#fragment",
+    },
+  };
+  const client = ErrorTracer.init({
+    runtime,
+    endpoint: "https://errors.example/api/v1/events",
+    projectKey: PROJECT_KEY,
+    release: " web@1 ",
+    environment: " production ",
+    tags: { region: " ap-southeast-1 " },
+    random: () => 0,
+    clock: () => FIXED_TIME,
+    transport(nextBody, nextPayload) {
+      body = nextBody;
+      payload = nextPayload;
+      return true;
+    },
+  });
+  const error = new Error(" boom ");
+  error.stack = " Error: boom\n    at checkout (app.js:10:5) ";
+
+  const accepted = await client.captureException(error, {
+    sourceURL: "https://cdn.example/app.js?build=1#source",
+    line: 10,
+    column: 5,
+    tags: { operation: " checkout " },
+  });
+
+  assert.equal(accepted, true);
+  assert.deepEqual(JSON.parse(body), payload);
+  assert.equal(payload.project_key, PROJECT_KEY);
+  assert.deepEqual(payload.event, {
+    kind: "error",
+    message: "boom",
+    stack: "Error: boom\n    at checkout (app.js:10:5)",
+    source_url: "https://cdn.example/app.js",
+    page_url: "https://app.example/checkout",
+    line: 10,
+    column: 5,
+    occurred_at: FIXED_TIME.toISOString(),
+    release: "web@1",
+    environment: "production",
+    tags: {
+      region: "ap-southeast-1",
+      operation: "checkout",
+    },
+  });
+});
+
+test("captures messages and bounds UTF-8 fields", async () => {
+  const events = [];
+  const client = testClient({
+    release: "r".repeat(200),
+    environment: "e".repeat(200),
+    tags: Object.fromEntries(
+      Array.from({ length: 40 }, (_, index) => [`tag-${index}`, "界".repeat(100)]),
+    ),
+    transport(_body, payload) {
+      events.push(payload.event);
+      return true;
+    },
+  });
+
+  assert.equal(await client.captureMessage("界".repeat(2000)), true);
+  assert.equal(await client.captureMessage("   "), false);
+  assert.equal(await client.capture({ kind: "resource_error" }), false);
+
+  assert.equal(Buffer.byteLength(events[0].message), 4095);
+  assert.equal(Buffer.byteLength(events[0].release), 128);
+  assert.equal(Buffer.byteLength(events[0].environment), 128);
+  assert.equal(Object.keys(events[0].tags).length, 32);
+  assert.ok(Object.values(events[0].tags).every((value) => Buffer.byteLength(value) <= 256));
+});
+
+test("beforeSend can modify or drop an event", async () => {
+  const events = [];
+  const client = testClient({
+    beforeSend(event) {
+      if (event.message === "drop") {
+        return null;
+      }
+      event.message = `filtered: ${event.message}`;
+      event.tags = { filtered: "yes" };
+      return event;
+    },
+    transport(_body, payload) {
+      events.push(payload.event);
+      return true;
+    },
+  });
+
+  assert.equal(await client.captureMessage("drop"), false);
+  assert.equal(await client.captureMessage("keep"), true);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].message, "filtered: keep");
+  assert.deepEqual(events[0].tags, { filtered: "yes" });
+});
+
+test("sampling and the per-minute budget bound traffic", async () => {
+  let sent = 0;
+  const sampledOut = testClient({
+    sampleRate: 0.5,
+    random: () => 0.75,
+    transport() {
+      sent++;
+      return true;
+    },
+  });
+  assert.equal(await sampledOut.captureMessage("sampled"), false);
+  assert.equal(sent, 0);
+
+  let now = FIXED_TIME;
+  const limited = testClient({
+    maxEventsPerMinute: 2,
+    random: () => 0,
+    clock: () => now,
+    transport() {
+      sent++;
+      return true;
+    },
+  });
+  assert.equal(await limited.captureMessage("one"), true);
+  assert.equal(await limited.captureMessage("two"), true);
+  assert.equal(await limited.captureMessage("three"), false);
+  now = new Date(now.getTime() + 60_001);
+  assert.equal(await limited.captureMessage("four"), true);
+  assert.equal(sent, 3);
+});
+
+test("default transport prefers sendBeacon with a simple text body", async () => {
+  let beacon;
+  let fetchCalled = false;
+  class FakeBlob {
+    constructor(parts, options) {
+      this.parts = parts;
+      this.type = options.type;
+    }
+  }
+  const runtime = {
+    Blob: FakeBlob,
+    location: { href: "https://app.example/page" },
+    navigator: {
+      sendBeacon(endpoint, blob) {
+        beacon = { endpoint, blob };
+        return true;
+      },
+    },
+    fetch() {
+      fetchCalled = true;
+      return Promise.resolve({ ok: true });
+    },
+  };
+  const client = ErrorTracer.init({
+    projectKey: PROJECT_KEY,
+    runtime,
+    endpoint: "https://errors.example/api/v1/events",
+    random: () => 0,
+    clock: () => FIXED_TIME,
+  });
+
+  assert.equal(await client.captureMessage("boom"), true);
+  assert.equal(beacon.endpoint, "https://errors.example/api/v1/events");
+  assert.equal(beacon.blob.type, "text/plain;charset=UTF-8");
+  assert.equal(JSON.parse(beacon.blob.parts[0]).event.message, "boom");
+  assert.equal(fetchCalled, false);
+});
+
+test("default transport falls back to credential-free fetch", async () => {
+  let request;
+  const runtime = {
+    location: { href: "https://app.example/page" },
+    navigator: {
+      sendBeacon() {
+        return false;
+      },
+    },
+    Blob,
+    fetch(endpoint, options) {
+      request = { endpoint, options };
+      return Promise.resolve({ ok: true });
+    },
+  };
+  const client = ErrorTracer.init({
+    projectKey: PROJECT_KEY,
+    runtime,
+    random: () => 0,
+    clock: () => FIXED_TIME,
+  });
+
+  assert.equal(await client.captureMessage("boom"), true);
+  assert.equal(request.endpoint, "/api/v1/events");
+  assert.equal(request.options.method, "POST");
+  assert.deepEqual(request.options.headers, { "Content-Type": "application/json" });
+  assert.equal(request.options.credentials, "omit");
+  assert.equal(request.options.keepalive, true);
+  assert.equal(JSON.parse(request.options.body).event.message, "boom");
+});
+
+test("capture contains extension and transport failures", async () => {
+  const badRandom = testClient({
+    random() {
+      throw new Error("random failed");
+    },
+  });
+  assert.equal(await badRandom.captureMessage("boom"), false);
+
+  const badHook = testClient({
+    beforeSend() {
+      throw new Error("hook failed");
+    },
+  });
+  assert.equal(await badHook.captureMessage("boom"), false);
+
+  const badTransport = testClient({
+    transport() {
+      return Promise.reject(new Error("offline"));
+    },
+  });
+  assert.equal(await badTransport.captureMessage("boom"), false);
+
+  const hostile = new Proxy({}, {
+    get() {
+      throw new Error("hostile getter");
+    },
+  });
+  assert.equal(await testClient().capture(hostile), false);
+});
+
+function testClient(overrides) {
+  return ErrorTracer.init({
+    projectKey: PROJECT_KEY,
+    runtime: { location: { href: "https://app.example/page" } },
+    random: () => 0,
+    clock: () => FIXED_TIME,
+    transport() {
+      return true;
+    },
+    ...overrides,
+  });
+}


### PR DESCRIPTION
## Summary

- add a dependency-free UMD/CommonJS browser client
- expose `ErrorTracer.init`, `captureException`, `captureMessage`, and the normalized `capture` path
- enforce the server event field and tag byte limits before transport
- remove credentials, query strings, and fragments from captured URLs
- add release, environment, and bounded tag context
- provide sampling and a per-tab event budget
- allow a synchronous `beforeSend` filter to modify or discard events
- prefer `sendBeacon` with a simple text body, then fall back to credential-free keepalive `fetch`
- contain hook, randomness, serialization, and transport failures instead of throwing into the host page

## Scope

This PR provides manual capture only. Global error listeners, embedded HTTP delivery, and the administration dashboard remain separate PRs.

The ingest key is expected to be browser-visible; this SDK never receives or stores the admin token.

## Validation

- `node --check sdk/error-tracer.js`
- `node --check sdk/error-tracer.test.js`
- `node --test sdk/*.test.js` — 8 tests
- `git diff --check`

The branch is one commit ahead of `master` and adds only the SDK package metadata, implementation, and core tests.