### PR TITLE
Clarify credential byte validation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,11 +47,11 @@ func FromEnvironment() (Config, error) {
 	}
 	ingestKey := strings.TrimSpace(os.Getenv("ERROR_TRACER_INGEST_KEY"))
 	if len(ingestKey) < 16 {
-		return Config{}, errors.New("ERROR_TRACER_INGEST_KEY must contain at least 16 characters")
+		return Config{}, errors.New("ERROR_TRACER_INGEST_KEY must contain at least 16 bytes")
 	}
 	adminToken := strings.TrimSpace(os.Getenv("ERROR_TRACER_ADMIN_TOKEN"))
 	if len(adminToken) < 24 {
-		return Config{}, errors.New("ERROR_TRACER_ADMIN_TOKEN must contain at least 24 characters")
+		return Config{}, errors.New("ERROR_TRACER_ADMIN_TOKEN must contain at least 24 bytes")
 	}
 	allowedOrigins, err := parseOrigins(os.Getenv("ERROR_TRACER_ALLOWED_ORIGINS"))
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -79,8 +80,9 @@ func TestFromEnvironmentRequiresIngestKey(t *testing.T) {
 	t.Setenv("ERROR_TRACER_INGEST_KEY", "short")
 	t.Setenv("ERROR_TRACER_ADMIN_TOKEN", "0123456789abcdefghijklmn")
 
-	if _, err := FromEnvironment(); err == nil {
-		t.Fatal("FromEnvironment() error = nil, want invalid ingest key error")
+	_, err := FromEnvironment()
+	if err == nil || err.Error() != "ERROR_TRACER_INGEST_KEY must contain at least 16 bytes" {
+		t.Fatalf("FromEnvironment() error = %v, want ingest key byte-length error", err)
 	}
 }
 
@@ -88,8 +90,22 @@ func TestFromEnvironmentRequiresAdminToken(t *testing.T) {
 	t.Setenv("ERROR_TRACER_INGEST_KEY", "0123456789abcdef")
 	t.Setenv("ERROR_TRACER_ADMIN_TOKEN", "short")
 
-	if _, err := FromEnvironment(); err == nil {
-		t.Fatal("FromEnvironment() error = nil, want invalid admin token error")
+	_, err := FromEnvironment()
+	if err == nil || err.Error() != "ERROR_TRACER_ADMIN_TOKEN must contain at least 24 bytes" {
+		t.Fatalf("FromEnvironment() error = %v, want admin token byte-length error", err)
+	}
+}
+
+func TestFromEnvironmentCountsCredentialBytes(t *testing.T) {
+	t.Setenv("ERROR_TRACER_INGEST_KEY", strings.Repeat("é", 8))
+	t.Setenv("ERROR_TRACER_ADMIN_TOKEN", strings.Repeat("é", 12))
+
+	cfg, err := FromEnvironment()
+	if err != nil {
+		t.Fatalf("FromEnvironment() error = %v", err)
+	}
+	if len(cfg.IngestKey) != 16 || len(cfg.AdminToken) != 24 {
+		t.Fatalf("credential lengths = %d and %d bytes, want 16 and 24", len(cfg.IngestKey), len(cfg.AdminToken))
 	}
 }
 


### PR DESCRIPTION
## Summary

- describe the ingest-key and admin-token minimums as UTF-8 byte lengths, matching the actual Go validation
- assert the exact configuration errors for undersized credentials
- add a multibyte boundary test showing that 16-byte and 24-byte credentials are accepted

## Why

The service, browser SDK, and README use byte limits, but the backend error strings said “characters.” That was ambiguous for non-ASCII credentials. This PR aligns the public validation error with the existing behavior; it does not change the accepted credential set.

## Validation

- `go test ./internal/config`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

The branch is one commit ahead of `master` and changes only configuration validation messages and their tests.