### PR TITLE
Capture browser failures automatically

### DIFF
--- a/sdk/error-tracer.js
+++ b/sdk/error-tracer.js
@@ -57,6 +57,9 @@
       if (options.transport !== undefined && typeof options.transport !== "function") {
         throw new TypeError("ErrorTracer transport must be a function");
       }
+      if (options.autoCapture !== undefined && typeof options.autoCapture !== "boolean") {
+        throw new TypeError("ErrorTracer autoCapture must be a boolean");
+      }
 
       this.release = truncateUTF8(cleanString(options.release), LIMITS.release);
       this.environment = truncateUTF8(cleanString(options.environment), LIMITS.environment);
@@ -66,6 +69,86 @@
       this.clock = typeof options.clock === "function" ? options.clock : () => new Date();
       this.sentAt = [];
       this.transport = options.transport || defaultTransport(this.runtime, this.endpoint);
+      this.installed = false;
+      this.errorListener = (event) => this.captureWindowError(event);
+      this.rejectionListener = (event) => this.captureUnhandledRejection(event);
+      if (options.autoCapture !== false) {
+        this.install();
+      }
+    }
+
+    install() {
+      if (this.installed || !this.runtime) {
+        return false;
+      }
+      if (typeof this.runtime.addEventListener !== "function" ||
+          typeof this.runtime.removeEventListener !== "function") {
+        return false;
+      }
+      this.runtime.addEventListener("error", this.errorListener, true);
+      this.runtime.addEventListener("unhandledrejection", this.rejectionListener, false);
+      this.installed = true;
+      return true;
+    }
+
+    destroy() {
+      if (!this.installed) {
+        return;
+      }
+      if (this.runtime && typeof this.runtime.removeEventListener === "function") {
+        this.runtime.removeEventListener("error", this.errorListener, true);
+        this.runtime.removeEventListener("unhandledrejection", this.rejectionListener, false);
+      }
+      this.installed = false;
+    }
+
+    captureWindowError(errorEvent) {
+      try {
+        const target = safeRead(errorEvent, "target");
+        if (target && target !== this.runtime) {
+          const sourceURL = safeRead(target, "currentSrc") ||
+            safeRead(target, "src") || safeRead(target, "href");
+          const tagName = cleanString(safeRead(target, "tagName")).toLowerCase() || "resource";
+          this.settle(this.capture({
+            kind: "resource_error",
+            message: `Failed to load ${tagName}`,
+            source_url: sourceURL,
+          }));
+          return;
+        }
+
+        const error = safeRead(errorEvent, "error");
+        const details = errorDetails(error);
+        this.settle(this.capture({
+          kind: "error",
+          message: cleanString(safeRead(errorEvent, "message")) || details.message,
+          stack: details.stack,
+          source_url: safeRead(errorEvent, "filename"),
+          line: safeRead(errorEvent, "lineno"),
+          column: safeRead(errorEvent, "colno"),
+        }));
+      } catch (_) {
+        // Browser error handlers must never throw into the host page.
+      }
+    }
+
+    captureUnhandledRejection(rejectionEvent) {
+      try {
+        const details = rejectionDetails(safeRead(rejectionEvent, "reason"));
+        this.settle(this.capture({
+          kind: "unhandled_rejection",
+          message: details.message,
+          stack: details.stack,
+        }));
+      } catch (_) {
+        // Browser rejection handlers must never create another rejection.
+      }
+    }
+
+    settle(result) {
+      if (result && typeof result.catch === "function") {
+        result.catch(() => {});
+      }
     }
 
     captureException(error, context) {
@@ -250,6 +333,22 @@
       message,
       stack: cleanString(safeRead(error, "stack")),
     };
+  }
+
+  function rejectionDetails(reason) {
+    const details = errorDetails(reason);
+    if (details.message !== "[object Object]") {
+      return details;
+    }
+    try {
+      const serialized = JSON.stringify(reason);
+      if (serialized) {
+        details.message = serialized;
+      }
+    } catch (_) {
+      // Keep the safe string representation for circular values.
+    }
+    return details;
   }
 
   function normalizeTags(input) {

--- a/sdk/error-tracer.test.js
+++ b/sdk/error-tracer.test.js
@@ -21,6 +21,7 @@ test("validates client options", () => {
   assert.throws(() => ErrorTracer.init({ projectKey: PROJECT_KEY, maxEventsPerMinute: 1001 }), /maxEventsPerMinute/);
   assert.throws(() => ErrorTracer.init({ projectKey: PROJECT_KEY, beforeSend: true }), /beforeSend/);
   assert.throws(() => ErrorTracer.init({ projectKey: PROJECT_KEY, transport: true }), /transport/);
+  assert.throws(() => ErrorTracer.init({ projectKey: PROJECT_KEY, autoCapture: "yes" }), /autoCapture/);
 
   assert.ok(ErrorTracer.init({
     projectKey: "界".repeat(6),
@@ -263,6 +264,103 @@ test("capture contains extension and transport failures", async () => {
   assert.equal(await testClient().capture(hostile), false);
 });
 
+test("automatically captures runtime, resource, and rejection failures", async () => {
+  const events = [];
+  const runtime = fakeRuntime();
+  const client = ErrorTracer.init({
+    projectKey: PROJECT_KEY,
+    runtime,
+    random: () => 0,
+    clock: () => FIXED_TIME,
+    transport(_body, payload) {
+      events.push(payload.event);
+      return true;
+    },
+  });
+
+  assert.equal(client.installed, true);
+  runtime.dispatch("error", {
+    target: runtime,
+    error: Object.assign(new Error("runtime boom"), { stack: "Error: runtime boom\n at app.js:7:9" }),
+    message: "runtime boom",
+    filename: "https://app.example/app.js?build=1",
+    lineno: 7,
+    colno: 9,
+  });
+  runtime.dispatch("error", {
+    target: {
+      tagName: "SCRIPT",
+      currentSrc: "https://cdn.example/missing.js?token=secret#fragment",
+    },
+  });
+  runtime.dispatch("unhandledrejection", {
+    reason: Object.assign(new Error("promise boom"), { stack: "Error: promise boom\n at promise.js:2:1" }),
+  });
+  await eventLoopTurn();
+
+  assert.equal(events.length, 3);
+  assert.deepEqual(events.map((event) => event.kind), [
+    "error",
+    "resource_error",
+    "unhandled_rejection",
+  ]);
+  assert.equal(events[0].source_url, "https://app.example/app.js");
+  assert.equal(events[0].line, 7);
+  assert.equal(events[0].column, 9);
+  assert.equal(events[1].message, "Failed to load script");
+  assert.equal(events[1].source_url, "https://cdn.example/missing.js");
+  assert.equal(events[2].message, "promise boom");
+});
+
+test("automatic capture can be installed and destroyed idempotently", () => {
+  const runtime = fakeRuntime();
+  const client = ErrorTracer.init({
+    projectKey: PROJECT_KEY,
+    runtime,
+    autoCapture: false,
+    transport() {
+      return true;
+    },
+  });
+
+  assert.equal(client.installed, false);
+  assert.equal(runtime.listenerCount("error"), 0);
+  assert.equal(client.install(), true);
+  assert.equal(client.install(), false);
+  assert.equal(runtime.listenerCount("error"), 1);
+  assert.equal(runtime.listenerCount("unhandledrejection"), 1);
+
+  client.destroy();
+  client.destroy();
+  assert.equal(client.installed, false);
+  assert.equal(runtime.listenerCount("error"), 0);
+  assert.equal(runtime.listenerCount("unhandledrejection"), 0);
+});
+
+test("serializes plain-object rejection reasons", async () => {
+  const events = [];
+  const runtime = fakeRuntime();
+  ErrorTracer.init({
+    projectKey: PROJECT_KEY,
+    runtime,
+    random: () => 0,
+    clock: () => FIXED_TIME,
+    transport(_body, payload) {
+      events.push(payload.event);
+      return true;
+    },
+  });
+
+  runtime.dispatch("unhandledrejection", {
+    reason: { code: "E_CHECKOUT", retryable: false },
+  });
+  await eventLoopTurn();
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0].kind, "unhandled_rejection");
+  assert.equal(events[0].message, '{"code":"E_CHECKOUT","retryable":false}');
+});
+
 function testClient(overrides) {
   return ErrorTracer.init({
     projectKey: PROJECT_KEY,
@@ -274,4 +372,34 @@ function testClient(overrides) {
     },
     ...overrides,
   });
+}
+
+function fakeRuntime() {
+  const listeners = new Map();
+  return {
+    location: { href: "https://app.example/page?secret=1#fragment" },
+    addEventListener(type, listener) {
+      const registered = listeners.get(type) || new Set();
+      registered.add(listener);
+      listeners.set(type, registered);
+    },
+    removeEventListener(type, listener) {
+      const registered = listeners.get(type);
+      if (registered) {
+        registered.delete(listener);
+      }
+    },
+    dispatch(type, event) {
+      for (const listener of listeners.get(type) || []) {
+        listener(event);
+      }
+    },
+    listenerCount(type) {
+      return (listeners.get(type) || new Set()).size;
+    },
+  };
+}
+
+function eventLoopTurn() {
+  return new Promise((resolve) => setImmediate(resolve));
 }


### PR DESCRIPTION
## Summary

- install browser listeners for runtime errors, resource-load failures, and unhandled promise rejections
- enable automatic capture by default while supporting `autoCapture: false`
- expose idempotent `install()` and `destroy()` lifecycle methods so integrations do not duplicate listeners
- normalize `Error`, primitive, and plain-object rejection reasons through the existing bounded event pipeline
- preserve manual capture behavior and contain listener failures inside the SDK

## Scope

This PR extends only the browser SDK and its tests. Serving the SDK from the Go binary and the administration dashboard remain separate changes.

## Validation

- `node --check sdk/error-tracer.js`
- `node --check sdk/error-tracer.test.js`
- `node --test sdk/*.test.js` — 11 tests
- `git diff --check`

The branch is one commit ahead of `master` and changes only the SDK implementation and test file.