### PR TITLE
Filter issues by status

### DIFF
--- a/internal/server/issues.go
+++ b/internal/server/issues.go
@@ -31,6 +31,10 @@ func (s *Server) listIssues(w http.ResponseWriter, request *http.Request) {
 	}
 	options, err := parseListOptions(request)
 	if err != nil {
+		if errors.Is(err, store.ErrInvalidStatus) {
+			writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid_status", Field: "status"})
+			return
+		}
 		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid_pagination"})
 		return
 	}
@@ -132,6 +136,9 @@ func parseListOptions(request *http.Request) (store.ListOptions, error) {
 	if len(query["limit"]) > 1 || len(query["offset"]) > 1 {
 		return store.ListOptions{}, errors.New("pagination parameters must not be repeated")
 	}
+	if len(query["status"]) > 1 {
+		return store.ListOptions{}, store.ErrInvalidStatus
+	}
 
 	var options store.ListOptions
 	if raw := query.Get("limit"); raw != "" {
@@ -147,6 +154,12 @@ func parseListOptions(request *http.Request) (store.ListOptions, error) {
 			return store.ListOptions{}, errors.New("offset is out of range")
 		}
 		options.Offset = offset
+	}
+	if raw := query.Get("status"); raw != "" {
+		options.Status = store.IssueStatus(raw)
+		if !options.Status.Valid() {
+			return store.ListOptions{}, store.ErrInvalidStatus
+		}
 	}
 	return options, nil
 }

--- a/internal/server/issues_test.go
+++ b/internal/server/issues_test.go
@@ -100,6 +100,66 @@ func TestListIssuesRejectsInvalidPagination(t *testing.T) {
 	}
 }
 
+func TestListIssuesFiltersByStatus(t *testing.T) {
+	memory := store.NewMemory()
+	base := time.Date(2026, time.August, 29, 2, 0, 0, 0, time.UTC)
+	openEvent := event.Event{
+		Kind: event.KindError, Message: "open failure", ReceivedAt: base,
+	}
+	if _, err := memory.Record(context.Background(), "project-a", openEvent); err != nil {
+		t.Fatalf("record open issue: %v", err)
+	}
+	resolvedEvent := event.Event{
+		Kind: event.KindError, Message: "resolved failure", ReceivedAt: base.Add(time.Minute),
+	}
+	resolved, err := memory.Record(context.Background(), "project-a", resolvedEvent)
+	if err != nil {
+		t.Fatalf("record resolved issue: %v", err)
+	}
+	if _, err := memory.SetIssueStatus(
+		context.Background(), "project-a", resolved.Fingerprint, store.IssueStatusResolved,
+	); err != nil {
+		t.Fatalf("resolve issue: %v", err)
+	}
+	app := New(Options{
+		Store: memory, ProjectID: "project-a", IngestKey: "0123456789abcdef", AdminToken: testAdminToken,
+	})
+
+	response := httptest.NewRecorder()
+	app.Handler().ServeHTTP(response, authorizedRequest(
+		http.MethodGet, "/api/v1/issues?status=resolved",
+	))
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", response.Code, http.StatusOK, response.Body.String())
+	}
+	var page store.IssuePage
+	if err := json.NewDecoder(response.Body).Decode(&page); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if page.Total != 1 || len(page.Issues) != 1 ||
+		page.Issues[0].Status != store.IssueStatusResolved {
+		t.Fatalf("page = %#v, want one resolved issue", page)
+	}
+
+	for _, target := range []string{
+		"/api/v1/issues?status=closed",
+		"/api/v1/issues?status=open&status=resolved",
+	} {
+		invalid := httptest.NewRecorder()
+		app.Handler().ServeHTTP(invalid, authorizedRequest(http.MethodGet, target))
+		if invalid.Code != http.StatusBadRequest {
+			t.Fatalf("%s: status = %d, want %d", target, invalid.Code, http.StatusBadRequest)
+		}
+		var failure errorResponse
+		if err := json.NewDecoder(invalid.Body).Decode(&failure); err != nil {
+			t.Fatalf("decode invalid status response: %v", err)
+		}
+		if failure.Error != "invalid_status" || failure.Field != "status" {
+			t.Fatalf("failure = %#v, want invalid_status for status", failure)
+		}
+	}
+}
+
 func TestGetIssue(t *testing.T) {
 	memory := store.NewMemory()
 	captured := event.Event{Kind: event.KindError, Message: "boom", ReceivedAt: time.Now().UTC()}

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -97,12 +97,16 @@ func (m *Memory) ListIssues(ctx context.Context, projectID string, options ListO
 	if projectID == "" {
 		return IssuePage{}, ErrProjectRequired
 	}
+	if options.Status != "" && !options.Status.Valid() {
+		return IssuePage{}, ErrInvalidStatus
+	}
 	options = normalizeListOptions(options)
 
 	m.mu.RLock()
 	issues := make([]Issue, 0, len(m.issues))
 	for _, issue := range m.issues {
-		if issue.ProjectID == projectID {
+		if issue.ProjectID == projectID &&
+			(options.Status == "" || issue.Status == options.Status) {
 			issues = append(issues, cloneIssue(issue))
 		}
 	}

--- a/internal/store/memory_test.go
+++ b/internal/store/memory_test.go
@@ -85,6 +85,43 @@ func TestMemoryListIssuesIsBoundedAndOrdered(t *testing.T) {
 	}
 }
 
+func TestMemoryListIssuesFiltersByStatus(t *testing.T) {
+	memory := NewMemory()
+	base := time.Date(2026, time.August, 29, 1, 0, 0, 0, time.UTC)
+	openEvent := testEvent(base)
+	openEvent.Message = "open failure"
+	if _, err := memory.Record(context.Background(), "project-a", openEvent); err != nil {
+		t.Fatalf("record open issue: %v", err)
+	}
+	resolvedEvent := testEvent(base.Add(time.Minute))
+	resolvedEvent.Message = "resolved failure"
+	resolved, err := memory.Record(context.Background(), "project-a", resolvedEvent)
+	if err != nil {
+		t.Fatalf("record resolved issue: %v", err)
+	}
+	if _, err := memory.SetIssueStatus(
+		context.Background(), "project-a", resolved.Fingerprint, IssueStatusResolved,
+	); err != nil {
+		t.Fatalf("resolve issue: %v", err)
+	}
+
+	page, err := memory.ListIssues(
+		context.Background(), "project-a", ListOptions{Status: IssueStatusResolved},
+	)
+	if err != nil {
+		t.Fatalf("list resolved issues: %v", err)
+	}
+	if page.Total != 1 || len(page.Issues) != 1 ||
+		page.Issues[0].Message != "resolved failure" {
+		t.Fatalf("resolved page = %#v, want only the resolved issue", page)
+	}
+	if _, err := memory.ListIssues(
+		context.Background(), "project-a", ListOptions{Status: "closed"},
+	); !errors.Is(err, ErrInvalidStatus) {
+		t.Fatalf("invalid status error = %v, want ErrInvalidStatus", err)
+	}
+}
+
 func TestMemoryRecordIsConcurrencySafe(t *testing.T) {
 	memory := NewMemory()
 	captured := testEvent(time.Now())

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -164,6 +164,9 @@ func (s *SQLite) ListIssues(ctx context.Context, projectID string, options ListO
 	if err := ctx.Err(); err != nil {
 		return IssuePage{}, err
 	}
+	if options.Status != "" && !options.Status.Valid() {
+		return IssuePage{}, ErrInvalidStatus
+	}
 	options = normalizeListOptions(options)
 
 	transaction, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
@@ -172,21 +175,29 @@ func (s *SQLite) ListIssues(ctx context.Context, projectID string, options ListO
 	}
 	defer func() { _ = transaction.Rollback() }()
 
+	whereClause := "project_id = ?"
+	queryArguments := []any{projectID}
+	if options.Status != "" {
+		whereClause += " AND status = ?"
+		queryArguments = append(queryArguments, options.Status)
+	}
+
 	var total int
 	if err := transaction.QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM issues WHERE project_id = ?", projectID,
+		"SELECT COUNT(*) FROM issues WHERE "+whereClause, queryArguments...,
 	).Scan(&total); err != nil {
 		return IssuePage{}, fmt.Errorf("count issues: %w", err)
 	}
 
+	listArguments := append(append([]any{}, queryArguments...), options.Limit, options.Offset)
 	rows, err := transaction.QueryContext(ctx, `
 SELECT project_id, fingerprint, kind, message, source_url, line, column_number,
        status, occurrences, first_seen, last_seen, last_event
 FROM issues
-WHERE project_id = ?
+WHERE `+whereClause+`
 ORDER BY last_seen DESC, fingerprint ASC
 LIMIT ? OFFSET ?
-`, projectID, options.Limit, options.Offset)
+`, listArguments...)
 	if err != nil {
 		return IssuePage{}, fmt.Errorf("list issues: %w", err)
 	}

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -98,6 +98,44 @@ func TestSQLiteListIssuesIsProjectScopedBoundedAndOrdered(t *testing.T) {
 	}
 }
 
+func TestSQLiteListIssuesFiltersByStatus(t *testing.T) {
+	database := openTestSQLite(t, ":memory:")
+	t.Cleanup(func() { _ = database.Close() })
+	base := time.Date(2026, time.August, 29, 1, 0, 0, 0, time.UTC)
+	openEvent := testEvent(base)
+	openEvent.Message = "open failure"
+	if _, err := database.Record(context.Background(), "project-a", openEvent); err != nil {
+		t.Fatalf("record open issue: %v", err)
+	}
+	ignoredEvent := testEvent(base.Add(time.Minute))
+	ignoredEvent.Message = "ignored failure"
+	ignored, err := database.Record(context.Background(), "project-a", ignoredEvent)
+	if err != nil {
+		t.Fatalf("record ignored issue: %v", err)
+	}
+	if _, err := database.SetIssueStatus(
+		context.Background(), "project-a", ignored.Fingerprint, IssueStatusIgnored,
+	); err != nil {
+		t.Fatalf("ignore issue: %v", err)
+	}
+
+	page, err := database.ListIssues(
+		context.Background(), "project-a", ListOptions{Status: IssueStatusIgnored},
+	)
+	if err != nil {
+		t.Fatalf("list ignored issues: %v", err)
+	}
+	if page.Total != 1 || len(page.Issues) != 1 ||
+		page.Issues[0].Message != "ignored failure" {
+		t.Fatalf("ignored page = %#v, want only the ignored issue", page)
+	}
+	if _, err := database.ListIssues(
+		context.Background(), "project-a", ListOptions{Status: "closed"},
+	); !errors.Is(err, ErrInvalidStatus) {
+		t.Fatalf("invalid status error = %v, want ErrInvalidStatus", err)
+	}
+}
+
 func TestSQLiteRecordSerializesConcurrentWriters(t *testing.T) {
 	database := openTestSQLite(t, ":memory:")
 	t.Cleanup(func() { _ = database.Close() })

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -60,6 +60,7 @@ type Issue struct {
 type ListOptions struct {
 	Limit  int
 	Offset int
+	Status IssueStatus
 }
 
 // IssuePage is a stable page of issues and the total matching count.


### PR DESCRIPTION
## Summary

- add an optional `status` filter to bounded issue-list queries
- support `GET /api/v1/issues?status=open|resolved|ignored`
- return a stable `invalid_status` response for unknown or repeated status parameters
- keep pagination totals scoped to the selected status
- implement equivalent filtering and ordering in the memory and SQLite stores

## Scope

This PR adds one read-path feature. It does not alter status transitions, event ingestion, or browser SDK behavior.

## Validation

- `go test ./internal/store ./internal/server`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`

The branch is one commit ahead of `master` and changes only the issue-list API/store paths and their tests.