### PR TITLE
Serve the embedded browser SDK

### DIFF
--- a/internal/server/assets.go
+++ b/internal/server/assets.go
@@ -1,0 +1,28 @@
+package server
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/soulteary/Error-Tracer/sdk"
+)
+
+var (
+	browserSDKBody = sdk.BrowserScript()
+	browserSDKETag = fmt.Sprintf(`"%x"`, sha256.Sum256([]byte(browserSDKBody)))
+)
+
+func (s *Server) browserSDK(w http.ResponseWriter, request *http.Request) {
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	w.Header().Set("Content-Type", "text/javascript; charset=utf-8")
+	w.Header().Set("ETag", browserSDKETag)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	if request.Header.Get("If-None-Match") == browserSDKETag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(w, browserSDKBody)
+}

--- a/internal/server/assets_test.go
+++ b/internal/server/assets_test.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBrowserSDKAsset(t *testing.T) {
+	request := httptest.NewRequest(http.MethodGet, "/assets/error-tracer.js", nil)
+	response := httptest.NewRecorder()
+
+	newTestServer().Handler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
+	}
+	if !strings.Contains(response.Body.String(), "ErrorTracer") {
+		t.Fatal("browser SDK response does not contain the public API")
+	}
+	if got := response.Header().Get("Content-Type"); got != "text/javascript; charset=utf-8" {
+		t.Fatalf("Content-Type = %q", got)
+	}
+	if got := response.Header().Get("Cache-Control"); got != "public, max-age=300" {
+		t.Fatalf("Cache-Control = %q", got)
+	}
+	if got := response.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q", got)
+	}
+	if got := response.Header().Get("ETag"); got == "" {
+		t.Fatal("ETag is empty")
+	}
+}
+
+func TestBrowserSDKAssetSupportsConditionalRequest(t *testing.T) {
+	first := httptest.NewRecorder()
+	newTestServer().Handler().ServeHTTP(
+		first,
+		httptest.NewRequest(http.MethodGet, "/assets/error-tracer.js", nil),
+	)
+
+	request := httptest.NewRequest(http.MethodGet, "/assets/error-tracer.js", nil)
+	request.Header.Set("If-None-Match", first.Header().Get("ETag"))
+	response := httptest.NewRecorder()
+	newTestServer().Handler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusNotModified {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusNotModified)
+	}
+	if response.Body.Len() != 0 {
+		t.Fatalf("conditional response body length = %d, want 0", response.Body.Len())
+	}
+}
+
+func TestBrowserSDKAssetRestrictsMethod(t *testing.T) {
+	request := httptest.NewRequest(http.MethodPost, "/assets/error-tracer.js", nil)
+	response := httptest.NewRecorder()
+
+	newTestServer().Handler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusMethodNotAllowed)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -53,6 +53,7 @@ func New(options Options) *Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", server.health)
 	mux.HandleFunc("GET /readyz", server.readiness)
+	mux.HandleFunc("GET /assets/error-tracer.js", server.browserSDK)
 	mux.HandleFunc("POST /api/v1/events", server.ingestEventWithOrigin)
 	mux.HandleFunc("OPTIONS /api/v1/events", server.preflightEvent)
 	mux.HandleFunc("GET /api/v1/issues", server.listIssues)

--- a/sdk/embed.go
+++ b/sdk/embed.go
@@ -1,0 +1,12 @@
+// Package sdk embeds the browser client distributed by Error-Tracer.
+package sdk
+
+import _ "embed"
+
+//go:embed error-tracer.js
+var browserScript string
+
+// BrowserScript returns the embedded, dependency-free browser client.
+func BrowserScript() string {
+	return browserScript
+}


### PR DESCRIPTION
## Summary

- embed the browser SDK in the Go binary with `go:embed`
- serve it from `GET /assets/error-tracer.js`
- return a content-derived strong ETag and honor `If-None-Match`
- add a short public cache lifetime and `X-Content-Type-Options: nosniff`
- test route registration, headers, body parity, and conditional responses

## Scope

This PR only makes the existing SDK deployable from the same origin as the collector. It does not add the administration dashboard or change SDK capture behavior.

## Validation

- `go test ./internal/server`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `node --test`
- `git diff --check`

The branch is one commit ahead of `master` and changes four files dedicated to embedded SDK delivery.