### PR TITLE
Harden credential comparison timing

### DIFF
--- a/internal/server/ingest.go
+++ b/internal/server/ingest.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
@@ -125,10 +126,9 @@ func ensureJSONEnd(decoder *json.Decoder) error {
 }
 
 func constantTimeEqual(left, right string) bool {
-	if len(left) != len(right) {
-		return false
-	}
-	return subtle.ConstantTimeCompare([]byte(left), []byte(right)) == 1
+	leftDigest := sha256.Sum256([]byte(left))
+	rightDigest := sha256.Sum256([]byte(right))
+	return subtle.ConstantTimeCompare(leftDigest[:], rightDigest[:]) == 1
 }
 
 func randomEventID() (string, error) {

--- a/internal/server/ingest_test.go
+++ b/internal/server/ingest_test.go
@@ -200,3 +200,25 @@ func TestIngestNormalizesBeforeValidation(t *testing.T) {
 		t.Fatalf("normalized event validation: %v", err)
 	}
 }
+
+func TestConstantTimeEqualSupportsVariableLengthCredentials(t *testing.T) {
+	tests := []struct {
+		name  string
+		left  string
+		right string
+		want  bool
+	}{
+		{name: "equal", left: "0123456789abcdef", right: "0123456789abcdef", want: true},
+		{name: "same length mismatch", left: "0123456789abcdef", right: "0123456789abcdeg"},
+		{name: "short mismatch", left: "short", right: "0123456789abcdef"},
+		{name: "long mismatch", left: "0123456789abcdef-extra", right: "0123456789abcdef"},
+		{name: "empty values", left: "", right: "", want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := constantTimeEqual(test.left, test.right); got != test.want {
+				t.Fatalf("constantTimeEqual() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- hash both supplied and configured credentials to fixed-size SHA-256 digests before comparison
- remove the direct length-mismatch early return from the shared credential comparison path
- exercise equal, same-length mismatch, shorter, longer, and empty-value cases

## Security impact

Both the browser-visible ingest key and the private admin bearer token use this helper. Comparing fixed-size digests avoids making the equality step return early solely because the candidate and configured credential lengths differ.

## Validation

- `go test ./internal/server`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`

The branch is one commit ahead of `master` and changes only the credential helper and its focused regression test.