### PR TITLE
Add a non-root container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.gitignore
+.github
+.env
+*.db
+*.db-*
+node_modules
+
+# The v1 runtime is preserved by the v1.0.0-legacy tag and is not required to
+# compile the rewritten service.
+config.yaml
+file*.js
+index.php
+push
+static

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1.7
+
+FROM golang:1.27.0-bookworm AS build
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY . .
+
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -trimpath -ldflags="-s -w" -o /out/error-tracer ./cmd/error-tracer && \
+    mkdir -p /out/data
+
+FROM scratch
+
+LABEL org.opencontainers.image.source="https://github.com/soulteary/Error-Tracer" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.title="Error-Tracer"
+
+COPY --from=build --chown=65532:65532 /out/error-tracer /error-tracer
+COPY --from=build --chown=65532:65532 /out/data /data
+COPY --from=build /src/LICENSE /licenses/Error-Tracer/LICENSE
+COPY --from=build /src/NOTICE /licenses/Error-Tracer/NOTICE
+
+USER 65532:65532
+WORKDIR /data
+
+ENV ERROR_TRACER_ADDRESS=:8080 \
+    ERROR_TRACER_DATABASE_PATH=/data/error-tracer.db
+
+EXPOSE 8080
+STOPSIGNAL SIGTERM
+
+ENTRYPOINT ["/error-tracer"]


### PR DESCRIPTION
## Summary

- add a cache-aware multi-stage Docker build using the Go 1.27 toolchain
- produce a stripped, statically linked Linux binary for BuildKit target architectures
- run the `scratch` image as numeric user/group `65532:65532`
- create an owned `/data` directory and default SQLite storage there
- include OCI source/license/title labels plus the Apache `LICENSE` and `NOTICE`
- exclude repository metadata, local databases, dependencies, and legacy runtime files from the build context

## Scope

This PR adds only the base image. The executable healthcheck and Compose deployment are intentionally separate changes.

## Validation

- `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath ./cmd/error-tracer`
- `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -trimpath ./cmd/error-tracer`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`

Docker and Podman are not available in the execution environment, so the complete image build could not be run here. Both target binaries were built locally and verified as static Linux executables.

The branch is one commit ahead of `master` and changes only `Dockerfile` and `.dockerignore`.