### PR TITLE
Add a readiness healthcheck command

### DIFF
--- a/cmd/error-tracer/main.go
+++ b/cmd/error-tracer/main.go
@@ -11,11 +11,21 @@ import (
 	"time"
 
 	"github.com/soulteary/Error-Tracer/internal/config"
+	"github.com/soulteary/Error-Tracer/internal/healthcheck"
 	appserver "github.com/soulteary/Error-Tracer/internal/server"
 	"github.com/soulteary/Error-Tracer/internal/store"
 )
 
 func main() {
+	if len(os.Args) == 2 && os.Args[1] == "healthcheck" {
+		address := os.Getenv("ERROR_TRACER_ADDRESS")
+		if err := healthcheck.Check(context.Background(), address); err != nil {
+			slog.Error("health check failed", "error", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	cfg, err := config.FromEnvironment()
 	if err != nil {
 		slog.Error("invalid configuration", "error", err)

--- a/internal/healthcheck/healthcheck.go
+++ b/internal/healthcheck/healthcheck.go
@@ -1,0 +1,78 @@
+// Package healthcheck implements the self-contained container readiness probe.
+package healthcheck
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultAddress = ":8080"
+	probeTimeout   = 2 * time.Second
+)
+
+// Check requests the local readiness endpoint derived from the listen address.
+func Check(ctx context.Context, address string) error {
+	target, err := targetURL(address)
+	if err != nil {
+		return err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return fmt.Errorf("create readiness request: %w", err)
+	}
+	client := &http.Client{
+		Timeout: probeTimeout,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("request readiness endpoint: %w", err)
+	}
+	defer response.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 4*1024))
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("readiness endpoint returned %s", response.Status)
+	}
+	return nil
+}
+
+func targetURL(address string) (string, error) {
+	address = strings.TrimSpace(address)
+	if address == "" {
+		address = defaultAddress
+	}
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return "", fmt.Errorf("parse listen address %q: %w", address, err)
+	}
+	if strings.TrimSpace(port) == "" {
+		return "", errors.New("listen address port is empty")
+	}
+	portNumber, err := net.LookupPort("tcp", port)
+	if err != nil {
+		return "", fmt.Errorf("resolve listen port %q: %w", port, err)
+	}
+	port = strconv.Itoa(portNumber)
+	switch host {
+	case "", "0.0.0.0":
+		host = "127.0.0.1"
+	case "::":
+		host = "::1"
+	}
+	return (&url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort(host, port),
+		Path:   "/readyz",
+	}).String(), nil
+}

--- a/internal/healthcheck/healthcheck_test.go
+++ b/internal/healthcheck/healthcheck_test.go
@@ -1,0 +1,84 @@
+package healthcheck
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCheckRequestsReadiness(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", request.Method)
+		}
+		if request.URL.Path != "/readyz" {
+			t.Errorf("path = %q, want /readyz", request.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ready"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	address := strings.TrimPrefix(server.URL, "http://")
+	if err := Check(context.Background(), address); err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+}
+
+func TestCheckRejectsUnreadyAndRedirectResponses(t *testing.T) {
+	for _, status := range []int{http.StatusServiceUnavailable, http.StatusFound} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if status == http.StatusFound {
+					w.Header().Set("Location", "/readyz")
+				}
+				w.WriteHeader(status)
+			}))
+			t.Cleanup(server.Close)
+
+			if err := Check(
+				context.Background(), strings.TrimPrefix(server.URL, "http://"),
+			); err == nil {
+				t.Fatalf("Check() error = nil for HTTP %d", status)
+			}
+		})
+	}
+}
+
+func TestCheckHonorsCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := Check(ctx, "127.0.0.1:8080"); err == nil {
+		t.Fatal("Check() error = nil for cancelled context")
+	}
+}
+
+func TestTargetURL(t *testing.T) {
+	tests := map[string]string{
+		"":                "http://127.0.0.1:8080/readyz",
+		":9090":           "http://127.0.0.1:9090/readyz",
+		"0.0.0.0:9090":    "http://127.0.0.1:9090/readyz",
+		"[::]:9090":       "http://[::1]:9090/readyz",
+		"localhost:9090":  "http://localhost:9090/readyz",
+		"192.0.2.10:9090": "http://192.0.2.10:9090/readyz",
+	}
+	for input, want := range tests {
+		got, err := targetURL(input)
+		if err != nil {
+			t.Fatalf("targetURL(%q) error = %v", input, err)
+		}
+		if got != want {
+			t.Errorf("targetURL(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestTargetURLRejectsInvalidAddress(t *testing.T) {
+	for _, address := range []string{"localhost", "127.0.0.1", ":not-a-port", "http://localhost:8080"} {
+		if _, err := targetURL(address); err == nil {
+			t.Errorf("targetURL(%q) error = nil", address)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- add `error-tracer healthcheck` as a self-contained readiness probe
- derive a loopback `/readyz` URL from `ERROR_TRACER_ADDRESS`, including wildcard IPv4 and IPv6 listeners
- require an HTTP 200 response, reject redirects, cap response reads, and enforce a two-second client timeout
- run the probe before normal configuration loading so container health checks do not require project credentials or database access
- cover defaults, explicit addresses, wildcard listeners, cancellation, non-ready responses, redirects, and malformed addresses

## Scope

This PR adds the executable probe only. Declaring it in the container image remains a separate one-line Dockerfile change.

## Validation

- `go test ./internal/healthcheck`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- live-process check against the service `/readyz` endpoint
- `git diff --check`

The branch is one commit ahead of `master` and changes only the entry point plus the isolated healthcheck package and tests.