### PR TITLE
Declare the container healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,6 @@ ENV ERROR_TRACER_ADDRESS=:8080 \
 
 EXPOSE 8080
 STOPSIGNAL SIGTERM
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 CMD ["/error-tracer", "healthcheck"]
 
 ENTRYPOINT ["/error-tracer"]


### PR DESCRIPTION
## Summary

- declare the built-in `error-tracer healthcheck` command as the image health probe
- use exec form so the `scratch` image needs no shell
- probe readiness every 30 seconds with a three-second runtime timeout, five-second startup grace period, and three retries

## Scope

This PR intentionally changes one Dockerfile line. The probe implementation and tests landed separately in #24.

## Validation

- `go test ./internal/healthcheck`
- live-process healthcheck against `/readyz`
- static Linux binary contains the `healthcheck` command
- `git diff --check`

Docker and Podman are unavailable in the execution environment, so the image-level health transition was not exercised here.

The branch is one commit ahead of `master` and modifies only `Dockerfile`.