### PR TITLE
Add hardened Compose deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Copy this file to .env and replace both blank credentials with independent,
+# randomly generated values before starting the service.
+ERROR_TRACER_INGEST_KEY=
+ERROR_TRACER_ADMIN_TOKEN=
+
+# One Error-Tracer process currently owns one project namespace.
+ERROR_TRACER_PROJECT_ID=default
+
+# Comma-separated exact browser origins. Keep blank for non-browser ingestion.
+ERROR_TRACER_ALLOWED_ORIGINS=https://app.example.com
+
+ERROR_TRACER_PORT=8080
+ERROR_TRACER_RATE_PER_MINUTE=120
+ERROR_TRACER_RATE_BURST=30

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 /*.iml
+.env
+*.db
+*.db-journal
+*.db-shm
+*.db-wal

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,31 @@
+services:
+  error-tracer:
+    build:
+      context: .
+    image: error-tracer:local
+    init: true
+    restart: unless-stopped
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    ports:
+      - "${ERROR_TRACER_PORT:-8080}:8080"
+    environment:
+      ERROR_TRACER_ADDRESS: ":8080"
+      ERROR_TRACER_DATABASE_PATH: "/data/error-tracer.db"
+      ERROR_TRACER_PROJECT_ID: "${ERROR_TRACER_PROJECT_ID:-default}"
+      ERROR_TRACER_INGEST_KEY: "${ERROR_TRACER_INGEST_KEY:?Set ERROR_TRACER_INGEST_KEY in .env}"
+      ERROR_TRACER_ADMIN_TOKEN: "${ERROR_TRACER_ADMIN_TOKEN:?Set ERROR_TRACER_ADMIN_TOKEN in .env}"
+      ERROR_TRACER_ALLOWED_ORIGINS: "${ERROR_TRACER_ALLOWED_ORIGINS:-}"
+      ERROR_TRACER_RATE_PER_MINUTE: "${ERROR_TRACER_RATE_PER_MINUTE:-120}"
+      ERROR_TRACER_RATE_BURST: "${ERROR_TRACER_RATE_BURST:-30}"
+    volumes:
+      - error-tracer-data:/data
+    tmpfs:
+      - /tmp:mode=1777,size=16m
+    stop_grace_period: 15s
+
+volumes:
+  error-tracer-data:


### PR DESCRIPTION
## Summary

- add a local Compose deployment that builds the repository image and persists SQLite data in a named volume
- require independent ingest and admin credentials through `.env`
- expose project, exact-origin allowlist, port, and ingestion rate-limit settings
- run with a read-only root filesystem, all Linux capabilities dropped, and `no-new-privileges`
- provide a bounded temporary filesystem, init process, restart policy, and graceful-stop window
- ignore local credentials plus SQLite database, journal, WAL, and shared-memory files

## Scope

This PR adds deployment configuration only; it does not change the service or image implementation.

## Validation

- parse `compose.yaml` and `.env.example`-related YAML with PyYAML
- verify `.env`, database, journal, WAL, and shared-memory paths are ignored
- `go test ./...`
- `git diff --check`

Docker Compose is unavailable in the execution environment, so the complete deployment was not started here.

The branch is one commit ahead of `master` and changes only the Compose file, environment template, and ignore rules.