### PR TITLE
Add continuous integration checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,93 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - "**/*.md"
+      - LICENSE
+      - NOTICE
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - LICENSE
+      - NOTICE
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  go:
+    name: Go
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify modules
+        run: go mod verify
+
+      - name: Check formatting
+        shell: bash
+        run: |
+          mapfile -d '' go_files < <(git ls-files -z '*.go')
+          unformatted="$(gofmt -l "${go_files[@]}")"
+          if [[ -n "${unformatted}" ]]; then
+            printf '%s\n' "${unformatted}"
+            exit 1
+          fi
+
+      - name: Check patch whitespace
+        run: git diff --check HEAD^ HEAD
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...
+
+      - name: Test with race detector
+        if: github.event_name != 'pull_request'
+        run: go test -race ./...
+
+      - name: Build static binary
+        run: CGO_ENABLED=0 go build -trimpath -o /tmp/error-tracer ./cmd/error-tracer
+
+  browser-sdk:
+    name: Browser SDK
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
+      - name: Check JavaScript syntax
+        run: |
+          node --check sdk/error-tracer.js
+          node --check internal/server/dashboard/dashboard.js
+
+      - name: Test browser SDK
+        run: node --test sdk/*.test.js


### PR DESCRIPTION
## Summary

- add pull-request, `master`, and manual CI triggers with docs-only path exclusions
- run module verification, repository-wide `gofmt` checks, patch whitespace checks, vet, tests, and a static service build
- run the race detector on trusted `master` pushes and manual executions without slowing every pull request
- check both browser JavaScript entry points and run the dependency-free SDK test suite on Node.js 24
- use read-only repository permissions, credential-free checkouts, pinned action commit SHAs, timeouts, and per-PR concurrency cancellation

## Validation

Local equivalents of every job step passed:

- `go mod verify`
- repository-wide `gofmt -l`
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`
- `CGO_ENABLED=0 go build -trimpath ./cmd/error-tracer`
- `node --check` for the SDK and dashboard
- `node --test sdk/*.test.js` — 11 tests
- YAML parsing and `git diff --check`

The branch is one commit ahead of `master` and adds only the CI workflow.