### PR TITLE
Schedule dependency update pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "03:00"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: deps
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "03:15"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: deps
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "03:30"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: deps


### PR DESCRIPTION
## Summary

- schedule weekly Go module updates
- schedule weekly updates for pinned GitHub Actions
- schedule weekly Docker base-image updates
- stagger the three update windows by 15 minutes
- cap each ecosystem at three open pull requests and use a consistent `deps` commit prefix

## Validation

- parse `.github/dependabot.yml` as YAML
- verify all three ecosystem directories target the repository root
- `git diff --check`

The branch is one commit ahead of `master` and adds only the Dependabot configuration.