### PR TITLE
Ignore local SQLite database artifacts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,16 @@
 .env
 *.db
 *.db-*
+*.db3
+*.db3-*
+*.s3db
+*.s3db-*
+*.sl3
+*.sl3-*
+*.sqlite
+*.sqlite-*
+*.sqlite3
+*.sqlite3-*
 node_modules
 
 # The v1 runtime is preserved by the v1.0.0-legacy tag and is not required to

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,16 @@
 /*.iml
 .env
+
+# Local SQLite databases and their journal/WAL sidecars.
 *.db
-*.db-journal
-*.db-shm
-*.db-wal
+*.db-*
+*.db3
+*.db3-*
+*.s3db
+*.s3db-*
+*.sl3
+*.sl3-*
+*.sqlite
+*.sqlite-*
+*.sqlite3
+*.sqlite3-*


### PR DESCRIPTION
## Summary

- ignore common SQLite database extensions
- ignore rollback-journal, WAL, and shared-memory sidecars
- keep the same database exclusions out of the Docker build context

## Verification

- `git check-ignore -v` for `.db`, `.db3`, `.s3db`, `.sl3`, `.sqlite`, and `.sqlite3` files and their sidecars
- `git diff --check`