### PR TITLE
Add atomic SQLite batch ingestion

### DIFF
--- a/internal/server/ingest.go
+++ b/internal/server/ingest.go
@@ -16,16 +16,29 @@ import (
 	"github.com/soulteary/Error-Tracer/internal/event"
 )
 
-const maxEventBodySize = 128 * 1024
+const (
+	maxEventBodySize = 128 * 1024
+	maxBatchBodySize = 1024 * 1024
+	maxBatchEvents   = 100
+)
 
 type ingestRequest struct {
 	ProjectKey string      `json:"project_key"`
 	Event      event.Event `json:"event"`
 }
 
+type batchIngestRequest struct {
+	ProjectKey string        `json:"project_key"`
+	Events     []event.Event `json:"events"`
+}
+
 type ingestResponse struct {
 	ID          string `json:"id"`
 	Fingerprint string `json:"fingerprint"`
+}
+
+type batchIngestResponse struct {
+	Events []ingestResponse `json:"events"`
 }
 
 type errorResponse struct {
@@ -66,12 +79,8 @@ func (s *Server) ingestEvent(w http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	captured := payload.Event
-	captured.ID = ""
-	captured.ReceivedAt = s.now().UTC()
-	captured.UserAgent = request.UserAgent()
-	captured.Normalize()
-	if err := captured.Validate(); err != nil {
+	captured, err := s.prepareEvent(payload.Event, request.UserAgent())
+	if err != nil {
 		var validationErr *event.ValidationError
 		if errors.As(err, &validationErr) {
 			writeJSON(w, http.StatusUnprocessableEntity, errorResponse{
@@ -80,16 +89,10 @@ func (s *Server) ingestEvent(w http.ResponseWriter, request *http.Request) {
 			})
 			return
 		}
-		writeJSON(w, http.StatusUnprocessableEntity, errorResponse{Error: "invalid_event"})
-		return
-	}
-
-	id, err := s.newID()
-	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "internal_error"})
 		return
 	}
-	captured.ID = id
+
 	issue, err := s.store.Record(request.Context(), s.projectID, captured)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "internal_error"})
@@ -97,9 +100,98 @@ func (s *Server) ingestEvent(w http.ResponseWriter, request *http.Request) {
 	}
 
 	writeJSON(w, http.StatusAccepted, ingestResponse{
-		ID:          id,
+		ID:          captured.ID,
 		Fingerprint: issue.Fingerprint,
 	})
+}
+
+func (s *Server) ingestBatch(w http.ResponseWriter, request *http.Request) {
+	if s.store == nil || s.projectID == "" || s.ingestKey == "" {
+		writeJSON(w, http.StatusServiceUnavailable, errorResponse{Error: "ingest_unavailable"})
+		return
+	}
+	if !supportedMediaType(request.Header.Get("Content-Type")) {
+		writeJSON(w, http.StatusUnsupportedMediaType, errorResponse{Error: "unsupported_media_type"})
+		return
+	}
+
+	request.Body = http.MaxBytesReader(w, request.Body, maxBatchBodySize)
+	decoder := json.NewDecoder(request.Body)
+	decoder.DisallowUnknownFields()
+
+	var payload batchIngestRequest
+	if err := decoder.Decode(&payload); err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, errorResponse{Error: "batch_too_large"})
+			return
+		}
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid_json"})
+		return
+	}
+	if err := ensureJSONEnd(decoder); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid_json"})
+		return
+	}
+	if !constantTimeEqual(payload.ProjectKey, s.ingestKey) {
+		writeJSON(w, http.StatusUnauthorized, errorResponse{Error: "invalid_project_key"})
+		return
+	}
+	if len(payload.Events) == 0 || len(payload.Events) > maxBatchEvents {
+		writeJSON(w, http.StatusUnprocessableEntity, errorResponse{
+			Error: "invalid_batch",
+			Field: "events",
+		})
+		return
+	}
+
+	captured := make([]event.Event, len(payload.Events))
+	for index, item := range payload.Events {
+		prepared, err := s.prepareEvent(item, request.UserAgent())
+		if err != nil {
+			var validationErr *event.ValidationError
+			if errors.As(err, &validationErr) {
+				writeJSON(w, http.StatusUnprocessableEntity, errorResponse{
+					Error: "invalid_event",
+					Field: fmt.Sprintf("events[%d].%s", index, validationErr.Field),
+				})
+				return
+			}
+			writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "internal_error"})
+			return
+		}
+		captured[index] = prepared
+	}
+
+	issues, err := s.store.RecordBatch(request.Context(), s.projectID, captured)
+	if err != nil || len(issues) != len(captured) {
+		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "internal_error"})
+		return
+	}
+	response := batchIngestResponse{Events: make([]ingestResponse, len(captured))}
+	for index := range captured {
+		response.Events[index] = ingestResponse{
+			ID:          captured[index].ID,
+			Fingerprint: issues[index].Fingerprint,
+		}
+	}
+	writeJSON(w, http.StatusAccepted, response)
+}
+
+func (s *Server) prepareEvent(captured event.Event, userAgent string) (event.Event, error) {
+	captured.ID = ""
+	captured.ReceivedAt = s.now().UTC()
+	captured.UserAgent = userAgent
+	captured.Normalize()
+	if err := captured.Validate(); err != nil {
+		return event.Event{}, err
+	}
+	id, err := s.newID()
+	if err != nil {
+		return event.Event{}, err
+	}
+	captured.ID = id
+	return captured, nil
 }
 
 func supportedMediaType(header string) bool {

--- a/internal/server/ingest_test.go
+++ b/internal/server/ingest_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -82,6 +83,131 @@ func TestIngestEventAcceptsBeaconTextPlain(t *testing.T) {
 
 	if response.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want %d; body = %s", response.Code, http.StatusAccepted, response.Body.String())
+	}
+}
+
+func TestIngestBatchWritesEventsAtomically(t *testing.T) {
+	memory := store.NewMemory()
+	app := New(Options{
+		Store:     memory,
+		ProjectID: "project-a",
+		IngestKey: "0123456789abcdef",
+	})
+	receivedAt := time.Date(2026, time.August, 29, 2, 0, 0, 0, time.UTC)
+	app.now = func() time.Time { return receivedAt }
+	ids := []string{"evt_first", "evt_second"}
+	app.newID = func() (string, error) {
+		id := ids[0]
+		ids = ids[1:]
+		return id, nil
+	}
+
+	body := `{
+		"project_key":"0123456789abcdef",
+		"events":[
+			{"kind":"error","message":" first "},
+			{"kind":"error","message":" second "}
+		]
+	}`
+	request := httptest.NewRequest(
+		http.MethodPost, "/api/v1/events/batch", strings.NewReader(body),
+	)
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", "batch-agent")
+	response := httptest.NewRecorder()
+
+	app.Handler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d; body = %s", response.Code, http.StatusAccepted, response.Body.String())
+	}
+	var result batchIngestResponse
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(result.Events) != 2 || result.Events[0].ID != "evt_first" ||
+		result.Events[1].ID != "evt_second" {
+		t.Fatalf("response = %#v, want two server-assigned IDs", result)
+	}
+	page, err := memory.ListIssues(context.Background(), "project-a", store.ListOptions{})
+	if err != nil {
+		t.Fatalf("list stored issues: %v", err)
+	}
+	if page.Total != 2 {
+		t.Fatalf("stored issues = %d, want 2", page.Total)
+	}
+	for _, issue := range page.Issues {
+		if !issue.LastEvent.ReceivedAt.Equal(receivedAt) ||
+			issue.LastEvent.UserAgent != "batch-agent" {
+			t.Fatalf("server-controlled batch fields = %#v", issue.LastEvent)
+		}
+	}
+}
+
+func TestIngestBatchRejectsEntireInvalidBatch(t *testing.T) {
+	memory := store.NewMemory()
+	app := New(Options{
+		Store:     memory,
+		ProjectID: "project-a",
+		IngestKey: "0123456789abcdef",
+	})
+	body := `{
+		"project_key":"0123456789abcdef",
+		"events":[
+			{"kind":"error","message":"valid"},
+			{"kind":"error"}
+		]
+	}`
+	request := httptest.NewRequest(
+		http.MethodPost, "/api/v1/events/batch", strings.NewReader(body),
+	)
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+
+	app.Handler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want %d; body = %s", response.Code, http.StatusUnprocessableEntity, response.Body.String())
+	}
+	var failure errorResponse
+	if err := json.NewDecoder(response.Body).Decode(&failure); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if failure.Error != "invalid_event" || failure.Field != "events[1].message" {
+		t.Fatalf("failure = %#v, want indexed validation error", failure)
+	}
+	page, err := memory.ListIssues(context.Background(), "project-a", store.ListOptions{})
+	if err != nil {
+		t.Fatalf("list stored issues: %v", err)
+	}
+	if page.Total != 0 {
+		t.Fatalf("stored issues = %d, want no partial batch", page.Total)
+	}
+}
+
+func TestIngestBatchEnforcesBounds(t *testing.T) {
+	for _, count := range []int{0, maxBatchEvents + 1} {
+		t.Run(fmt.Sprintf("%d events", count), func(t *testing.T) {
+			events := make([]event.Event, count)
+			body, err := json.Marshal(batchIngestRequest{
+				ProjectKey: "0123456789abcdef",
+				Events:     events,
+			})
+			if err != nil {
+				t.Fatalf("encode request: %v", err)
+			}
+			request := httptest.NewRequest(
+				http.MethodPost, "/api/v1/events/batch", bytes.NewReader(body),
+			)
+			request.Header.Set("Content-Type", "application/json")
+			response := httptest.NewRecorder()
+
+			newTestServer().Handler().ServeHTTP(response, request)
+
+			if response.Code != http.StatusUnprocessableEntity {
+				t.Fatalf("status = %d, want %d; body = %s", response.Code, http.StatusUnprocessableEntity, response.Body.String())
+			}
+		})
 	}
 }
 

--- a/internal/server/origin.go
+++ b/internal/server/origin.go
@@ -6,16 +6,30 @@ import (
 )
 
 func (s *Server) ingestEventWithOrigin(w http.ResponseWriter, request *http.Request) {
-	if !s.allowEventOrigin(w, request) {
+	if !s.allowIngestRequest(w, request) {
 		return
+	}
+	s.ingestEvent(w, request)
+}
+
+func (s *Server) ingestBatchWithOrigin(w http.ResponseWriter, request *http.Request) {
+	if !s.allowIngestRequest(w, request) {
+		return
+	}
+	s.ingestBatch(w, request)
+}
+
+func (s *Server) allowIngestRequest(w http.ResponseWriter, request *http.Request) bool {
+	if !s.allowEventOrigin(w, request) {
+		return false
 	}
 	allowed, retryAfter := s.ingestLimiter.Allow(clientAddress(request.RemoteAddr))
 	if !allowed {
 		w.Header().Set("Retry-After", retryAfterHeader(retryAfter))
 		writeJSON(w, http.StatusTooManyRequests, errorResponse{Error: "rate_limited"})
-		return
+		return false
 	}
-	s.ingestEvent(w, request)
+	return true
 }
 
 func (s *Server) preflightEvent(w http.ResponseWriter, request *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -59,6 +59,8 @@ func New(options Options) *Server {
 	mux.HandleFunc("GET /assets/error-tracer.js", server.browserSDK)
 	mux.HandleFunc("POST /api/v1/events", server.ingestEventWithOrigin)
 	mux.HandleFunc("OPTIONS /api/v1/events", server.preflightEvent)
+	mux.HandleFunc("POST /api/v1/events/batch", server.ingestBatchWithOrigin)
+	mux.HandleFunc("OPTIONS /api/v1/events/batch", server.preflightEvent)
 	mux.HandleFunc("GET /api/v1/issues", server.listIssues)
 	mux.HandleFunc("GET /api/v1/issues/{fingerprint}", server.getIssue)
 	mux.HandleFunc("PATCH /api/v1/issues/{fingerprint}", server.updateIssue)

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -22,51 +22,64 @@ func NewMemory() *Memory {
 
 // Record adds an event to its fingerprint group.
 func (m *Memory) Record(ctx context.Context, projectID string, captured event.Event) (Issue, error) {
-	if err := ctx.Err(); err != nil {
+	issues, err := m.RecordBatch(ctx, projectID, []event.Event{captured})
+	if err != nil {
 		return Issue{}, err
 	}
-	projectID = strings.TrimSpace(projectID)
-	if projectID == "" {
-		return Issue{}, ErrProjectRequired
-	}
-	if captured.ReceivedAt.IsZero() {
-		return Issue{}, ErrReceivedAtEmpty
-	}
+	return issues[0], nil
+}
 
-	fingerprint := captured.Fingerprint()
-	key := issueKey(projectID, fingerprint)
-	captured = cloneEvent(captured)
+// RecordBatch atomically adds a non-empty batch of events.
+func (m *Memory) RecordBatch(ctx context.Context, projectID string, captured []event.Event) ([]Issue, error) {
+	projectID, err := validateRecordBatch(ctx, projectID, captured)
+	if err != nil {
+		return nil, err
+	}
+	events := make([]event.Event, len(captured))
+	for index, item := range captured {
+		events[index] = cloneEvent(item)
+	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	issue, exists := m.issues[key]
-	if !exists {
-		issue = Issue{
-			ProjectID:   projectID,
-			Fingerprint: fingerprint,
-			Kind:        captured.Kind,
-			Message:     captured.Message,
-			SourceURL:   captured.SourceURL,
-			Line:        captured.Line,
-			Column:      captured.Column,
-			Status:      IssueStatusOpen,
-			FirstSeen:   captured.ReceivedAt,
-			LastSeen:    captured.ReceivedAt,
-			LastEvent:   captured,
+	fingerprints := make([]string, len(events))
+	for index, item := range events {
+		fingerprint := item.Fingerprint()
+		fingerprints[index] = fingerprint
+		key := issueKey(projectID, fingerprint)
+		issue, exists := m.issues[key]
+		if !exists {
+			issue = Issue{
+				ProjectID:   projectID,
+				Fingerprint: fingerprint,
+				Kind:        item.Kind,
+				Message:     item.Message,
+				SourceURL:   item.SourceURL,
+				Line:        item.Line,
+				Column:      item.Column,
+				Status:      IssueStatusOpen,
+				FirstSeen:   item.ReceivedAt,
+				LastSeen:    item.ReceivedAt,
+				LastEvent:   item,
+			}
 		}
-	}
 
-	issue.Occurrences++
-	if captured.ReceivedAt.Before(issue.FirstSeen) {
-		issue.FirstSeen = captured.ReceivedAt
+		issue.Occurrences++
+		if item.ReceivedAt.Before(issue.FirstSeen) {
+			issue.FirstSeen = item.ReceivedAt
+		}
+		if !item.ReceivedAt.Before(issue.LastSeen) {
+			issue.LastSeen = item.ReceivedAt
+			issue.LastEvent = item
+		}
+		m.issues[key] = issue
 	}
-	if !captured.ReceivedAt.Before(issue.LastSeen) {
-		issue.LastSeen = captured.ReceivedAt
-		issue.LastEvent = captured
+	issues := make([]Issue, len(events))
+	for index, fingerprint := range fingerprints {
+		issues[index] = cloneIssue(m.issues[issueKey(projectID, fingerprint)])
 	}
-	m.issues[key] = issue
-	return cloneIssue(issue), nil
+	return issues, nil
 }
 
 // GetIssue returns one issue from one project.

--- a/internal/store/memory_test.go
+++ b/internal/store/memory_test.go
@@ -41,6 +41,48 @@ func TestMemoryRecordAggregatesMatchingEvents(t *testing.T) {
 	}
 }
 
+func TestMemoryRecordBatchAggregatesAndValidatesBeforeWriting(t *testing.T) {
+	memory := NewMemory()
+	firstTime := time.Date(2026, time.August, 29, 1, 0, 0, 0, time.UTC)
+	first := testEvent(firstTime)
+	second := testEvent(firstTime.Add(time.Minute))
+	second.Release = "2.0.0"
+
+	issues, err := memory.RecordBatch(
+		context.Background(), "project-a", []event.Event{first, second},
+	)
+	if err != nil {
+		t.Fatalf("record batch: %v", err)
+	}
+	if len(issues) != 2 || issues[0].Occurrences != 2 || issues[1].Occurrences != 2 {
+		t.Fatalf("batch issues = %#v, want two views of the final aggregate", issues)
+	}
+	if issues[1].LastEvent.Release != "2.0.0" {
+		t.Fatalf("last event = %#v, want second batch event", issues[1].LastEvent)
+	}
+
+	invalid := testEvent(firstTime.Add(2 * time.Minute))
+	invalid.Message = "must not be stored"
+	invalid.ReceivedAt = time.Time{}
+	if _, err := memory.RecordBatch(
+		context.Background(), "project-a", []event.Event{testEvent(firstTime), invalid},
+	); !errors.Is(err, ErrReceivedAtEmpty) {
+		t.Fatalf("invalid batch error = %v, want ErrReceivedAtEmpty", err)
+	}
+	page, err := memory.ListIssues(context.Background(), "project-a", ListOptions{})
+	if err != nil {
+		t.Fatalf("list issues: %v", err)
+	}
+	if page.Total != 1 || page.Issues[0].Occurrences != 2 {
+		t.Fatalf("page after invalid batch = %#v, want the original two events only", page)
+	}
+	if _, err := memory.RecordBatch(
+		context.Background(), "project-a", nil,
+	); !errors.Is(err, ErrEventsRequired) {
+		t.Fatalf("empty batch error = %v, want ErrEventsRequired", err)
+	}
+}
+
 func TestMemorySeparatesProjects(t *testing.T) {
 	memory := NewMemory()
 	captured := testEvent(time.Now())

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -34,6 +34,21 @@ CREATE INDEX IF NOT EXISTS issues_project_status_last_seen
     ON issues (project_id, status, last_seen DESC);
 `
 
+const sqliteUpsertIssue = `
+INSERT INTO issues (
+    project_id, fingerprint, kind, message, source_url, line, column_number,
+    status, occurrences, first_seen, last_seen, last_event
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)
+ON CONFLICT (project_id, fingerprint) DO UPDATE SET
+    occurrences = issues.occurrences + 1,
+    first_seen = MIN(issues.first_seen, excluded.first_seen),
+    last_event = CASE
+        WHEN excluded.last_seen >= issues.last_seen THEN excluded.last_event
+        ELSE issues.last_event
+    END,
+    last_seen = MAX(issues.last_seen, excluded.last_seen)
+`
+
 var ErrDatabasePathRequired = errors.New("database path is required")
 
 // SQLite persists aggregated issues in a local SQLite database.
@@ -90,57 +105,84 @@ func (s *SQLite) Close() error {
 
 // Record atomically adds an event to its fingerprint group.
 func (s *SQLite) Record(ctx context.Context, projectID string, captured event.Event) (Issue, error) {
-	projectID = strings.TrimSpace(projectID)
-	if projectID == "" {
-		return Issue{}, ErrProjectRequired
-	}
-	if captured.ReceivedAt.IsZero() {
-		return Issue{}, ErrReceivedAtEmpty
-	}
-	if err := ctx.Err(); err != nil {
+	issues, err := s.RecordBatch(ctx, projectID, []event.Event{captured})
+	if err != nil {
 		return Issue{}, err
 	}
+	return issues[0], nil
+}
 
-	fingerprint := captured.Fingerprint()
-	encodedEvent, err := json.Marshal(captured)
+type sqliteRecord struct {
+	event       event.Event
+	fingerprint string
+	encoded     []byte
+	receivedAt  int64
+}
+
+// RecordBatch adds every event in one transaction. Any failed write or read
+// rolls the entire batch back, so callers never observe a partial batch.
+func (s *SQLite) RecordBatch(ctx context.Context, projectID string, captured []event.Event) ([]Issue, error) {
+	projectID, err := validateRecordBatch(ctx, projectID, captured)
 	if err != nil {
-		return Issue{}, fmt.Errorf("encode event: %w", err)
+		return nil, err
 	}
-	receivedAt := captured.ReceivedAt.UnixNano()
+	records := make([]sqliteRecord, len(captured))
+	for index, item := range captured {
+		encoded, encodeErr := json.Marshal(item)
+		if encodeErr != nil {
+			return nil, fmt.Errorf("encode event %d: %w", index, encodeErr)
+		}
+		records[index] = sqliteRecord{
+			event:       item,
+			fingerprint: item.Fingerprint(),
+			encoded:     encoded,
+			receivedAt:  item.ReceivedAt.UnixNano(),
+		}
+	}
 
 	transaction, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return Issue{}, fmt.Errorf("begin record transaction: %w", err)
+		return nil, fmt.Errorf("begin record batch transaction: %w", err)
 	}
 	defer func() { _ = transaction.Rollback() }()
 
-	_, err = transaction.ExecContext(ctx, `
-INSERT INTO issues (
-    project_id, fingerprint, kind, message, source_url, line, column_number,
-    status, occurrences, first_seen, last_seen, last_event
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)
-ON CONFLICT (project_id, fingerprint) DO UPDATE SET
-    occurrences = issues.occurrences + 1,
-    first_seen = MIN(issues.first_seen, excluded.first_seen),
-    last_event = CASE
-        WHEN excluded.last_seen >= issues.last_seen THEN excluded.last_event
-        ELSE issues.last_event
-    END,
-    last_seen = MAX(issues.last_seen, excluded.last_seen)
-`, projectID, fingerprint, captured.Kind, captured.Message, captured.SourceURL,
-		captured.Line, captured.Column, IssueStatusOpen, receivedAt, receivedAt, encodedEvent)
+	statement, err := transaction.PrepareContext(ctx, sqliteUpsertIssue)
 	if err != nil {
-		return Issue{}, fmt.Errorf("upsert issue: %w", err)
+		return nil, fmt.Errorf("prepare issue batch: %w", err)
+	}
+	for index, record := range records {
+		_, err = statement.ExecContext(
+			ctx, projectID, record.fingerprint, record.event.Kind,
+			record.event.Message, record.event.SourceURL, record.event.Line,
+			record.event.Column, IssueStatusOpen, record.receivedAt,
+			record.receivedAt, record.encoded,
+		)
+		if err != nil {
+			_ = statement.Close()
+			return nil, fmt.Errorf("upsert issue for event %d: %w", index, err)
+		}
+	}
+	if err := statement.Close(); err != nil {
+		return nil, fmt.Errorf("close issue batch statement: %w", err)
 	}
 
-	issue, err := queryIssue(ctx, transaction, projectID, fingerprint)
-	if err != nil {
-		return Issue{}, err
+	issues := make([]Issue, len(records))
+	issuesByFingerprint := make(map[string]Issue, len(records))
+	for index, record := range records {
+		issue, exists := issuesByFingerprint[record.fingerprint]
+		if !exists {
+			issue, err = queryIssue(ctx, transaction, projectID, record.fingerprint)
+			if err != nil {
+				return nil, fmt.Errorf("read issue for event %d: %w", index, err)
+			}
+			issuesByFingerprint[record.fingerprint] = issue
+		}
+		issues[index] = issue
 	}
 	if err := transaction.Commit(); err != nil {
-		return Issue{}, fmt.Errorf("commit record transaction: %w", err)
+		return nil, fmt.Errorf("commit record batch transaction: %w", err)
 	}
-	return issue, nil
+	return issues, nil
 }
 
 // GetIssue returns one issue from one project.

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/soulteary/Error-Tracer/internal/event"
 )
 
 func TestSQLiteRecordPersistsAggregatedIssue(t *testing.T) {
@@ -44,6 +46,58 @@ func TestSQLiteRecordPersistsAggregatedIssue(t *testing.T) {
 	}
 	if persisted.Occurrences != 2 || persisted.LastEvent.Release != "2.0.0" {
 		t.Fatalf("persisted issue = %#v", persisted)
+	}
+}
+
+func TestSQLiteRecordBatchUsesOneAtomicTransaction(t *testing.T) {
+	database := openTestSQLite(t, ":memory:")
+	t.Cleanup(func() { _ = database.Close() })
+	base := time.Date(2026, time.August, 29, 1, 0, 0, 0, time.UTC)
+	first := testEvent(base)
+	second := testEvent(base.Add(time.Minute))
+	second.Release = "2.0.0"
+
+	issues, err := database.RecordBatch(
+		context.Background(), "project-a", []event.Event{first, second},
+	)
+	if err != nil {
+		t.Fatalf("record batch: %v", err)
+	}
+	if len(issues) != 2 || issues[0].Occurrences != 2 || issues[1].Occurrences != 2 {
+		t.Fatalf("batch issues = %#v, want two views of the final aggregate", issues)
+	}
+	if issues[1].LastEvent.Release != "2.0.0" {
+		t.Fatalf("last event = %#v, want second batch event", issues[1].LastEvent)
+	}
+
+	if _, err := database.db.Exec(`
+CREATE TRIGGER reject_batch_event
+BEFORE INSERT ON issues
+WHEN NEW.message = 'reject batch'
+BEGIN
+    SELECT RAISE(ABORT, 'rejected batch event');
+END;
+`); err != nil {
+		t.Fatalf("create rejection trigger: %v", err)
+	}
+	accepted := testEvent(base.Add(2 * time.Minute))
+	accepted.Message = "would be written without rollback"
+	rejected := testEvent(base.Add(3 * time.Minute))
+	rejected.Message = "reject batch"
+	if _, err := database.RecordBatch(
+		context.Background(), "project-a", []event.Event{accepted, rejected},
+	); err == nil {
+		t.Fatal("record rejected batch error = nil")
+	}
+	if _, err := database.GetIssue(
+		context.Background(), "project-a", accepted.Fingerprint(),
+	); !errors.Is(err, ErrIssueNotFound) {
+		t.Fatalf("first event in failed batch error = %v, want ErrIssueNotFound", err)
+	}
+	if _, err := database.RecordBatch(
+		context.Background(), "project-a", nil,
+	); !errors.Is(err, ErrEventsRequired) {
+		t.Fatalf("empty batch error = %v, want ErrEventsRequired", err)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4,6 +4,7 @@ package store
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/soulteary/Error-Tracer/internal/event"
@@ -18,6 +19,7 @@ var (
 	ErrIssueNotFound   = errors.New("issue not found")
 	ErrInvalidStatus   = errors.New("invalid issue status")
 	ErrProjectRequired = errors.New("project ID is required")
+	ErrEventsRequired  = errors.New("at least one event is required")
 	ErrReceivedAtEmpty = errors.New("event received_at is required")
 )
 
@@ -74,6 +76,7 @@ type IssuePage struct {
 // Store records events and exposes their aggregated issues.
 type Store interface {
 	Record(context.Context, string, event.Event) (Issue, error)
+	RecordBatch(context.Context, string, []event.Event) ([]Issue, error)
 	GetIssue(context.Context, string, string) (Issue, error)
 	ListIssues(context.Context, string, ListOptions) (IssuePage, error)
 	SetIssueStatus(context.Context, string, string, IssueStatus) (Issue, error)
@@ -90,4 +93,23 @@ func normalizeListOptions(options ListOptions) ListOptions {
 		options.Offset = 0
 	}
 	return options
+}
+
+func validateRecordBatch(ctx context.Context, projectID string, captured []event.Event) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return "", ErrProjectRequired
+	}
+	if len(captured) == 0 {
+		return "", ErrEventsRequired
+	}
+	for _, item := range captured {
+		if item.ReceivedAt.IsZero() {
+			return "", ErrReceivedAtEmpty
+		}
+	}
+	return projectID, nil
 }


### PR DESCRIPTION
## Summary

- add `Store.RecordBatch` with consistent in-memory and SQLite implementations
- prepare one UPSERT and execute the full SQLite batch in one transaction
- validate every event before writing and roll the entire transaction back on any failure
- add `POST /api/v1/events/batch` for bounded batches of up to 100 events
- preserve server-owned IDs, timestamps, user agents, origin policy, and rate limiting

## Atomicity coverage

- verifies same-fingerprint events aggregate within one batch
- installs a test-only SQLite trigger that aborts the second insert and verifies the first insert is rolled back
- verifies validation failures leave the in-memory store unchanged
- verifies invalid HTTP batches persist no partial data

## Verification

- `npm test` (11 passing)
- `git diff --check`
- Go formatting, vet, tests, race tests, and static build run in CI