### PR TITLE
Run CI after pushes to the default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - "**/*.md"
       - LICENSE


### PR DESCRIPTION
## Summary

The repository default branch is `main`, but the CI workflow only listened for pushes to `master`. This prevented post-merge checks such as the race detector from running on the branch that is actually deployed.

This PR changes the push trigger to `main`. Pull-request and manual triggers remain unchanged.

## Verification

- confirmed the repository default branch is `main`
- `git diff --check`