### PR TITLE
test: add database benchmarks and an HTTP load tester

### DIFF
--- a/cmd/error-tracer-loadtest/main.go
+++ b/cmd/error-tracer-loadtest/main.go
@@ -1,0 +1,454 @@
+// Command error-tracer-loadtest drives the batch ingestion endpoint for
+// deliberate performance and capacity testing.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+const (
+	ingestKeyEnvironment = "ERROR_TRACER_INGEST_KEY"
+	batchEndpointPath    = "/api/v1/events/batch"
+)
+
+var latencyBounds = []time.Duration{
+	250 * time.Microsecond,
+	500 * time.Microsecond,
+	1 * time.Millisecond,
+	2 * time.Millisecond,
+	5 * time.Millisecond,
+	10 * time.Millisecond,
+	20 * time.Millisecond,
+	50 * time.Millisecond,
+	100 * time.Millisecond,
+	200 * time.Millisecond,
+	500 * time.Millisecond,
+	1 * time.Second,
+	2 * time.Second,
+	5 * time.Second,
+	10 * time.Second,
+	30 * time.Second,
+	60 * time.Second,
+}
+
+type loadConfig struct {
+	endpoint       string
+	projectKey     string
+	duration       time.Duration
+	timeout        time.Duration
+	concurrency    int
+	batchSize      int
+	cardinality    int
+	requestsPerSec int
+	failOnError    bool
+}
+
+type loadEvent struct {
+	Kind        string            `json:"kind"`
+	Message     string            `json:"message"`
+	SourceURL   string            `json:"source_url"`
+	PageURL     string            `json:"page_url"`
+	Line        int               `json:"line"`
+	Column      int               `json:"column"`
+	Environment string            `json:"environment"`
+	Tags        map[string]string `json:"tags"`
+}
+
+type loadPayload struct {
+	ProjectKey string      `json:"project_key"`
+	Events     []loadEvent `json:"events"`
+}
+
+type observation struct {
+	status    int
+	latency   time.Duration
+	transport bool
+}
+
+type histogram struct {
+	counts []uint64
+	total  uint64
+	max    time.Duration
+}
+
+type loadSummary struct {
+	elapsed         time.Duration
+	requests        uint64
+	accepted        uint64
+	transportErrors uint64
+	statuses        map[int]uint64
+	latency         histogram
+	batchSize       int
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Getenv, os.Stdout, os.Stderr))
+}
+
+func run(args []string, getenv func(string) string, stdout, stderr io.Writer) int {
+	configuration, err := parseConfig(args, getenv, stderr)
+	if errors.Is(err, flag.ErrHelp) {
+		return 0
+	}
+	if err != nil {
+		fmt.Fprintf(stderr, "configuration error: %v\n", err)
+		return 2
+	}
+
+	signalContext, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	loadContext, cancel := context.WithTimeout(signalContext, configuration.duration)
+	defer cancel()
+
+	summary, err := runLoad(loadContext, configuration)
+	if err != nil {
+		fmt.Fprintf(stderr, "load test error: %v\n", err)
+		return 2
+	}
+	printSummary(stdout, configuration, summary)
+	if configuration.failOnError && summary.failed() {
+		return 1
+	}
+	return 0
+}
+
+func parseConfig(args []string, getenv func(string) string, output io.Writer) (loadConfig, error) {
+	flags := flag.NewFlagSet("error-tracer-loadtest", flag.ContinueOnError)
+	flags.SetOutput(output)
+	target := flags.String("target", "", "base URL or complete batch endpoint (required)")
+	projectKey := flags.String("project-key", "", "ingest key; defaults to ERROR_TRACER_INGEST_KEY")
+	duration := flags.Duration("duration", 10*time.Second, "test duration (1s to 30m)")
+	timeout := flags.Duration("timeout", 5*time.Second, "per-request timeout (100ms to 1m)")
+	concurrency := flags.Int("concurrency", 8, "number of concurrent workers (1 to 1000)")
+	batchSize := flags.Int("batch-size", 10, "events per request (1 to 100)")
+	cardinality := flags.Int("cardinality", 100, "distinct issue fingerprints (1 to 100000)")
+	requestsPerSec := flags.Int("rate", 0, "aggregate requests per second; 0 means unlimited")
+	allowRemote := flags.Bool("allow-remote", false, "permit a non-loopback target")
+	failOnError := flags.Bool("fail-on-error", true, "exit non-zero for transport or non-202 responses")
+	if err := flags.Parse(args); err != nil {
+		return loadConfig{}, err
+	}
+	if flags.NArg() != 0 {
+		return loadConfig{}, errors.New("positional arguments are not supported")
+	}
+
+	endpoint, err := normalizeTarget(*target, *allowRemote)
+	if err != nil {
+		return loadConfig{}, err
+	}
+	key := strings.TrimSpace(*projectKey)
+	if key == "" {
+		key = strings.TrimSpace(getenv(ingestKeyEnvironment))
+	}
+	if len(key) < 16 {
+		return loadConfig{}, errors.New("project key must contain at least 16 bytes")
+	}
+	if *duration < time.Second || *duration > 30*time.Minute {
+		return loadConfig{}, errors.New("duration must be between 1s and 30m")
+	}
+	if *timeout < 100*time.Millisecond || *timeout > time.Minute {
+		return loadConfig{}, errors.New("timeout must be between 100ms and 1m")
+	}
+	if *concurrency < 1 || *concurrency > 1_000 {
+		return loadConfig{}, errors.New("concurrency must be between 1 and 1000")
+	}
+	if *batchSize < 1 || *batchSize > 100 {
+		return loadConfig{}, errors.New("batch size must be between 1 and 100")
+	}
+	if *cardinality < 1 || *cardinality > 100_000 {
+		return loadConfig{}, errors.New("cardinality must be between 1 and 100000")
+	}
+	if *requestsPerSec < 0 || *requestsPerSec > 1_000_000 {
+		return loadConfig{}, errors.New("rate must be between 0 and 1000000 requests per second")
+	}
+
+	return loadConfig{
+		endpoint:       endpoint,
+		projectKey:     key,
+		duration:       *duration,
+		timeout:        *timeout,
+		concurrency:    *concurrency,
+		batchSize:      *batchSize,
+		cardinality:    *cardinality,
+		requestsPerSec: *requestsPerSec,
+		failOnError:    *failOnError,
+	}, nil
+}
+
+func normalizeTarget(value string, allowRemote bool) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", errors.New("target is required")
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", errors.New("target must be an absolute HTTP(S) URL")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", errors.New("target must use HTTP or HTTPS")
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", errors.New("target must not contain credentials, a query, or a fragment")
+	}
+	if parsed.Path == "" || parsed.Path == "/" {
+		parsed.Path = batchEndpointPath
+	} else if parsed.Path != batchEndpointPath {
+		return "", fmt.Errorf("target path must be empty or %s", batchEndpointPath)
+	}
+	if !allowRemote && !loopbackHost(parsed.Hostname()) {
+		return "", errors.New("refusing a non-loopback target without -allow-remote")
+	}
+	return parsed.String(), nil
+}
+
+func loopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	address := net.ParseIP(host)
+	return address != nil && address.IsLoopback()
+}
+
+func runLoad(ctx context.Context, configuration loadConfig) (loadSummary, error) {
+	payloads, err := buildPayloads(configuration)
+	if err != nil {
+		return loadSummary{}, err
+	}
+
+	transport := &http.Transport{
+		MaxIdleConns:        configuration.concurrency * 2,
+		MaxIdleConnsPerHost: configuration.concurrency,
+		MaxConnsPerHost:     configuration.concurrency,
+		IdleConnTimeout:     30 * time.Second,
+	}
+	defer transport.CloseIdleConnections()
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   configuration.timeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	var ticker *time.Ticker
+	var permits <-chan time.Time
+	var initialPermit atomic.Bool
+	if configuration.requestsPerSec > 0 {
+		ticker = time.NewTicker(time.Second / time.Duration(configuration.requestsPerSec))
+		defer ticker.Stop()
+		permits = ticker.C
+		initialPermit.Store(true)
+	}
+
+	started := time.Now()
+	results := make(chan observation, configuration.concurrency*2)
+	var sequence atomic.Uint64
+	var workers sync.WaitGroup
+	for range configuration.concurrency {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for waitForPermit(ctx, permits, &initialPermit) {
+				index := sequence.Add(1) - 1
+				payload := payloads[index%uint64(len(payloads))]
+				request, requestErr := http.NewRequestWithContext(
+					ctx, http.MethodPost, configuration.endpoint, bytes.NewReader(payload),
+				)
+				if requestErr != nil {
+					results <- observation{transport: true}
+					continue
+				}
+				request.Header.Set("Content-Type", "application/json")
+				request.Header.Set("Accept", "application/json")
+				request.Header.Set("User-Agent", "error-tracer-loadtest/1")
+
+				requestStarted := time.Now()
+				response, requestErr := client.Do(request)
+				latency := time.Since(requestStarted)
+				if requestErr != nil {
+					if ctx.Err() != nil {
+						return
+					}
+					results <- observation{latency: latency, transport: true}
+					continue
+				}
+				_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 64*1024))
+				_ = response.Body.Close()
+				results <- observation{status: response.StatusCode, latency: latency}
+			}
+		}()
+	}
+	go func() {
+		workers.Wait()
+		close(results)
+	}()
+
+	summary := loadSummary{
+		statuses:  make(map[int]uint64),
+		latency:   newHistogram(),
+		batchSize: configuration.batchSize,
+	}
+	for result := range results {
+		summary.requests++
+		if result.transport {
+			summary.transportErrors++
+			continue
+		}
+		summary.statuses[result.status]++
+		summary.latency.observe(result.latency)
+		if result.status == http.StatusAccepted {
+			summary.accepted++
+		}
+	}
+	summary.elapsed = time.Since(started)
+	return summary, nil
+}
+
+func waitForPermit(ctx context.Context, permits <-chan time.Time, initial *atomic.Bool) bool {
+	if permits == nil {
+		select {
+		case <-ctx.Done():
+			return false
+		default:
+			return true
+		}
+	}
+	if initial.CompareAndSwap(true, false) {
+		return true
+	}
+	select {
+	case <-ctx.Done():
+		return false
+	case <-permits:
+		return true
+	}
+}
+
+func buildPayloads(configuration loadConfig) ([][]byte, error) {
+	payloadCount := max(1, (configuration.cardinality+configuration.batchSize-1)/configuration.batchSize)
+	payloads := make([][]byte, payloadCount)
+	for payloadIndex := range payloads {
+		events := make([]loadEvent, configuration.batchSize)
+		for eventIndex := range events {
+			fingerprintIndex := (payloadIndex*configuration.batchSize + eventIndex) % configuration.cardinality
+			events[eventIndex] = loadEvent{
+				Kind:        "error",
+				Message:     fmt.Sprintf("load test failure %06d", fingerprintIndex),
+				SourceURL:   "https://loadtest.invalid/assets/app.js",
+				PageURL:     "https://loadtest.invalid/checkout",
+				Line:        42,
+				Column:      7,
+				Environment: "loadtest",
+				Tags:        map[string]string{"suite": "pressure"},
+			}
+		}
+		encoded, err := json.Marshal(loadPayload{
+			ProjectKey: configuration.projectKey,
+			Events:     events,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("encode payload %d: %w", payloadIndex, err)
+		}
+		payloads[payloadIndex] = encoded
+	}
+	return payloads, nil
+}
+
+func newHistogram() histogram {
+	return histogram{counts: make([]uint64, len(latencyBounds)+1)}
+}
+
+func (h *histogram) observe(value time.Duration) {
+	index := sort.Search(len(latencyBounds), func(index int) bool {
+		return value <= latencyBounds[index]
+	})
+	h.counts[index]++
+	h.total++
+	if value > h.max {
+		h.max = value
+	}
+}
+
+func (h histogram) percentile(quantile float64) time.Duration {
+	if h.total == 0 {
+		return 0
+	}
+	target := uint64(math.Ceil(float64(h.total) * quantile))
+	var cumulative uint64
+	for index, count := range h.counts {
+		cumulative += count
+		if cumulative >= target {
+			if index < len(latencyBounds) {
+				return latencyBounds[index]
+			}
+			return h.max
+		}
+	}
+	return h.max
+}
+
+func (summary loadSummary) failed() bool {
+	if summary.accepted == 0 || summary.transportErrors != 0 {
+		return true
+	}
+	for status, count := range summary.statuses {
+		if status != http.StatusAccepted && count != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func printSummary(output io.Writer, configuration loadConfig, summary loadSummary) {
+	seconds := max(summary.elapsed.Seconds(), 0.000_001)
+	acceptedEvents := summary.accepted * uint64(summary.batchSize)
+	fmt.Fprintln(output, "Error-Tracer load test")
+	fmt.Fprintf(output, "Target:       %s\n", configuration.endpoint)
+	fmt.Fprintf(output, "Elapsed:      %s\n", summary.elapsed.Round(time.Millisecond))
+	fmt.Fprintf(output, "Concurrency:  %d\n", configuration.concurrency)
+	fmt.Fprintf(output, "Batch size:   %d\n", configuration.batchSize)
+	fmt.Fprintf(output, "Requests:     %d (%.1f req/s)\n", summary.requests, float64(summary.requests)/seconds)
+	fmt.Fprintf(output, "Accepted:     %d requests / %d events (%.1f events/s)\n", summary.accepted, acceptedEvents, float64(acceptedEvents)/seconds)
+	fmt.Fprintf(output, "Transport:    %d errors\n", summary.transportErrors)
+	fmt.Fprintf(
+		output, "Latency:      p50 %s / p95 %s / p99 %s / max %s\n",
+		summary.latency.percentile(0.50), summary.latency.percentile(0.95),
+		summary.latency.percentile(0.99), summary.latency.max,
+	)
+
+	statuses := make([]int, 0, len(summary.statuses))
+	for status := range summary.statuses {
+		statuses = append(statuses, status)
+	}
+	sort.Ints(statuses)
+	fmt.Fprint(output, "HTTP status:  ")
+	if len(statuses) == 0 {
+		fmt.Fprintln(output, "none")
+		return
+	}
+	for index, status := range statuses {
+		if index != 0 {
+			fmt.Fprint(output, ", ")
+		}
+		fmt.Fprintf(output, "%d=%d", status, summary.statuses[status])
+	}
+	fmt.Fprintln(output)
+}

--- a/cmd/error-tracer-loadtest/main_test.go
+++ b/cmd/error-tracer-loadtest/main_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseConfigUsesEnvironmentKeyAndNormalizesTarget(t *testing.T) {
+	configuration, err := parseConfig(
+		[]string{
+			"-target", "http://127.0.0.1:8080",
+			"-duration", "2s",
+			"-concurrency", "4",
+			"-batch-size", "20",
+			"-cardinality", "40",
+			"-rate", "100",
+		},
+		func(name string) string {
+			if name == ingestKeyEnvironment {
+				return "0123456789abcdef"
+			}
+			return ""
+		},
+		io.Discard,
+	)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if configuration.endpoint != "http://127.0.0.1:8080/api/v1/events/batch" {
+		t.Fatalf("endpoint = %q", configuration.endpoint)
+	}
+	if configuration.projectKey != "0123456789abcdef" ||
+		configuration.duration != 2*time.Second ||
+		configuration.concurrency != 4 ||
+		configuration.batchSize != 20 ||
+		configuration.cardinality != 40 ||
+		configuration.requestsPerSec != 100 {
+		t.Fatalf("configuration = %#v", configuration)
+	}
+}
+
+func TestParseConfigProtectsRemoteTargets(t *testing.T) {
+	base := []string{
+		"-target", "https://errors.example.com",
+		"-project-key", "0123456789abcdef",
+	}
+	if _, err := parseConfig(base, func(string) string { return "" }, io.Discard); err == nil ||
+		!strings.Contains(err.Error(), "-allow-remote") {
+		t.Fatalf("remote target error = %v", err)
+	}
+
+	configuration, err := parseConfig(
+		append(base, "-allow-remote"), func(string) string { return "" }, io.Discard,
+	)
+	if err != nil {
+		t.Fatalf("allow remote target: %v", err)
+	}
+	if configuration.endpoint != "https://errors.example.com/api/v1/events/batch" {
+		t.Fatalf("endpoint = %q", configuration.endpoint)
+	}
+}
+
+func TestNormalizeTargetRejectsAmbiguousURLs(t *testing.T) {
+	for _, target := range []string{
+		"ftp://127.0.0.1/file",
+		"http://user@127.0.0.1:8080",
+		"http://127.0.0.1:8080/api/v1/events",
+		"http://127.0.0.1:8080?query=1",
+		"http://127.0.0.1:8080#fragment",
+	} {
+		if _, err := normalizeTarget(target, false); err == nil {
+			t.Fatalf("normalizeTarget(%q) error = nil", target)
+		}
+	}
+}
+
+func TestBuildPayloadsControlsBatchSizeAndCardinality(t *testing.T) {
+	configuration := loadConfig{
+		projectKey:  "0123456789abcdef",
+		batchSize:   3,
+		cardinality: 5,
+	}
+	payloads, err := buildPayloads(configuration)
+	if err != nil {
+		t.Fatalf("build payloads: %v", err)
+	}
+	if len(payloads) != 2 {
+		t.Fatalf("payload count = %d, want 2", len(payloads))
+	}
+	messages := make(map[string]bool)
+	for _, encoded := range payloads {
+		var payload loadPayload
+		if err := json.Unmarshal(encoded, &payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		if payload.ProjectKey != configuration.projectKey || len(payload.Events) != 3 {
+			t.Fatalf("payload = %#v", payload)
+		}
+		for _, captured := range payload.Events {
+			messages[captured.Message] = true
+		}
+	}
+	if len(messages) != 5 {
+		t.Fatalf("distinct messages = %d, want 5", len(messages))
+	}
+}
+
+func TestHistogramReportsBoundedPercentiles(t *testing.T) {
+	histogram := newHistogram()
+	for _, value := range []time.Duration{
+		100 * time.Microsecond,
+		800 * time.Microsecond,
+		3 * time.Millisecond,
+		12 * time.Millisecond,
+		90 * time.Second,
+	} {
+		histogram.observe(value)
+	}
+	if got := histogram.percentile(0.50); got != 5*time.Millisecond {
+		t.Fatalf("p50 = %s, want %s", got, 5*time.Millisecond)
+	}
+	if got := histogram.percentile(0.99); got != 90*time.Second {
+		t.Fatalf("p99 = %s, want %s", got, 90*time.Second)
+	}
+}
+
+func TestPrintSummaryDoesNotExposeProjectKey(t *testing.T) {
+	configuration := loadConfig{
+		endpoint:    "http://127.0.0.1:8080/api/v1/events/batch",
+		projectKey:  "secret-project-key",
+		concurrency: 2,
+		batchSize:   10,
+	}
+	histogram := newHistogram()
+	histogram.observe(time.Millisecond)
+	summary := loadSummary{
+		elapsed:   time.Second,
+		requests:  1,
+		accepted:  1,
+		statuses:  map[int]uint64{202: 1},
+		latency:   histogram,
+		batchSize: 10,
+	}
+	var output bytes.Buffer
+	printSummary(&output, configuration, summary)
+	if strings.Contains(output.String(), configuration.projectKey) {
+		t.Fatal("summary exposed the project key")
+	}
+}

--- a/internal/server/benchmark_test.go
+++ b/internal/server/benchmark_test.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/soulteary/Error-Tracer/internal/event"
+	"github.com/soulteary/Error-Tracer/internal/store"
+)
+
+func BenchmarkIngestHandler(b *testing.B) {
+	benchmarks := []struct {
+		name      string
+		path      string
+		batchSize int
+	}{
+		{name: "Single", path: "/api/v1/events", batchSize: 1},
+		{name: "Batch_010", path: "/api/v1/events/batch", batchSize: 10},
+		{name: "Batch_100", path: "/api/v1/events/batch", batchSize: 100},
+	}
+
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			body := benchmarkIngestBody(b, benchmark.batchSize, benchmark.path)
+			app := New(Options{
+				Store:         store.NewMemory(),
+				ProjectID:     "benchmark",
+				IngestKey:     "0123456789abcdef",
+				RatePerMinute: 1_000_000_000,
+				RateBurst:     1_000_000_000,
+			})
+			app.now = func() time.Time {
+				return time.Date(2026, time.August, 29, 12, 0, 0, 0, time.UTC)
+			}
+			app.newID = func() (string, error) { return "evt_benchmark", nil }
+
+			b.ReportAllocs()
+			b.ReportMetric(float64(benchmark.batchSize), "events/op")
+			b.SetBytes(int64(len(body)))
+			b.ResetTimer()
+			for range b.N {
+				request := httptest.NewRequest(http.MethodPost, benchmark.path, bytes.NewReader(body))
+				request.Header.Set("Content-Type", "application/json")
+				response := httptest.NewRecorder()
+				app.Handler().ServeHTTP(response, request)
+				if response.Code != http.StatusAccepted {
+					b.Fatalf("status = %d; body = %s", response.Code, response.Body.String())
+				}
+			}
+		})
+	}
+}
+
+func benchmarkIngestBody(b *testing.B, batchSize int, path string) []byte {
+	b.Helper()
+	events := make([]event.Event, batchSize)
+	for index := range events {
+		events[index] = event.Event{
+			Kind:        event.KindError,
+			Message:     fmt.Sprintf("benchmark failure %03d", index),
+			Stack:       "Error: benchmark failure\n    at run (https://benchmark.invalid/app.js:42:7)",
+			SourceURL:   "https://benchmark.invalid/app.js",
+			PageURL:     "https://benchmark.invalid/checkout",
+			Line:        42,
+			Column:      7,
+			Release:     "benchmark-1",
+			Environment: "benchmark",
+			Tags:        map[string]string{"suite": "http"},
+		}
+	}
+
+	var payload any
+	if path == "/api/v1/events" {
+		payload = ingestRequest{ProjectKey: "0123456789abcdef", Event: events[0]}
+	} else {
+		payload = batchIngestRequest{ProjectKey: "0123456789abcdef", Events: events}
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		b.Fatalf("marshal benchmark body: %v", err)
+	}
+	return body
+}

--- a/internal/store/benchmark_test.go
+++ b/internal/store/benchmark_test.go
@@ -1,0 +1,140 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/soulteary/Error-Tracer/internal/event"
+)
+
+func BenchmarkRecordBatch(b *testing.B) {
+	stores := []struct {
+		name string
+		open func(*testing.B) Store
+	}{
+		{
+			name: "Memory",
+			open: func(*testing.B) Store {
+				return NewMemory()
+			},
+		},
+		{
+			name: "SQLite",
+			open: func(b *testing.B) Store {
+				database, err := OpenSQLite(
+					context.Background(), filepath.Join(b.TempDir(), "benchmark.db"),
+				)
+				if err != nil {
+					b.Fatalf("open SQLite: %v", err)
+				}
+				b.Cleanup(func() { _ = database.Close() })
+				return database
+			},
+		},
+	}
+
+	for _, implementation := range stores {
+		b.Run(implementation.name, func(b *testing.B) {
+			for _, batchSize := range []int{1, 10, 100} {
+				b.Run(fmt.Sprintf("Batch_%03d", batchSize), func(b *testing.B) {
+					issueStore := implementation.open(b)
+					captured := benchmarkEvents(batchSize)
+					b.ReportAllocs()
+					b.ReportMetric(float64(batchSize), "events/op")
+					b.ResetTimer()
+					for range b.N {
+						if _, err := issueStore.RecordBatch(
+							context.Background(), "benchmark", captured,
+						); err != nil {
+							b.Fatalf("record batch: %v", err)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func BenchmarkListIssues(b *testing.B) {
+	stores := []struct {
+		name string
+		open func(*testing.B) Store
+	}{
+		{
+			name: "Memory",
+			open: func(*testing.B) Store {
+				return NewMemory()
+			},
+		},
+		{
+			name: "SQLite",
+			open: func(b *testing.B) Store {
+				database, err := OpenSQLite(
+					context.Background(), filepath.Join(b.TempDir(), "benchmark.db"),
+				)
+				if err != nil {
+					b.Fatalf("open SQLite: %v", err)
+				}
+				b.Cleanup(func() { _ = database.Close() })
+				return database
+			},
+		},
+	}
+
+	for _, implementation := range stores {
+		b.Run(implementation.name, func(b *testing.B) {
+			issueStore := implementation.open(b)
+			for offset := 0; offset < 1_000; offset += 100 {
+				captured := benchmarkEventsAt(100, offset)
+				if _, err := issueStore.RecordBatch(
+					context.Background(), "benchmark", captured,
+				); err != nil {
+					b.Fatalf("seed issues: %v", err)
+				}
+			}
+			options := ListOptions{Limit: 50, Offset: 475}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				page, err := issueStore.ListIssues(context.Background(), "benchmark", options)
+				if err != nil {
+					b.Fatalf("list issues: %v", err)
+				}
+				if len(page.Issues) != 50 || page.Total != 1_000 {
+					b.Fatalf("unexpected page: %d of %d", len(page.Issues), page.Total)
+				}
+			}
+		})
+	}
+}
+
+func benchmarkEvents(count int) []event.Event {
+	return benchmarkEventsAt(count, 0)
+}
+
+func benchmarkEventsAt(count, offset int) []event.Event {
+	receivedAt := time.Date(2026, time.August, 29, 12, 0, 0, 0, time.UTC)
+	captured := make([]event.Event, count)
+	for index := range captured {
+		number := offset + index
+		captured[index] = event.Event{
+			ID:          fmt.Sprintf("evt_benchmark_%06d", number),
+			Kind:        event.KindError,
+			Message:     fmt.Sprintf("benchmark failure %06d", number),
+			Stack:       fmt.Sprintf("Error: benchmark failure %06d\n    at run (https://benchmark.invalid/app.js:42:7)", number),
+			SourceURL:   "https://benchmark.invalid/app.js",
+			PageURL:     "https://benchmark.invalid/checkout",
+			Line:        42,
+			Column:      7,
+			ReceivedAt:  receivedAt.Add(time.Duration(number) * time.Millisecond),
+			Release:     "benchmark-1",
+			Environment: "benchmark",
+			UserAgent:   "error-tracer-benchmark",
+			Tags:        map[string]string{"suite": "store"},
+		}
+	}
+	return captured
+}


### PR DESCRIPTION
## Summary

- benchmark atomic batch writes for the in-memory and SQLite stores at 1, 10, and 100 events
- benchmark paginated reads over 1,000 issues for both store implementations
- benchmark the complete single and batch ingest HTTP handlers
- add a dependency-free `error-tracer-loadtest` command for end-to-end pressure tests
- report accepted request/event throughput, HTTP status counts, transport errors, and p50/p95/p99/max latency

## Load-test safety

- refuses non-loopback targets unless `-allow-remote` is explicit
- disables redirects and does not use an HTTP proxy
- bounds duration, concurrency, batch size, issue cardinality, request rate, and timeout
- reads `ERROR_TRACER_INGEST_KEY` by default and never prints the key
- exits non-zero on transport or non-202 responses by default

## Verification

- `go test ./...`
- `go vet ./...`
- benchmark smoke run with `-benchtime=1x`
- live 1-second SQLite-backed run: 49 accepted requests / 490 events, no transport errors, all HTTP 202
- `git diff --check`