### PR TITLE
feat: add English and Simplified Chinese dashboard locales

### DIFF
--- a/internal/server/dashboard/dashboard.css
+++ b/internal/server/dashboard/dashboard.css
@@ -64,6 +64,17 @@ a:focus-visible {
   display: none !important;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .ambient {
   position: fixed;
   z-index: 0;
@@ -101,6 +112,27 @@ a:focus-visible {
   justify-content: space-between;
   min-height: 56px;
   margin-bottom: 72px;
+}
+
+.masthead-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.language-control select {
+  min-height: 34px;
+  padding: 0 30px 0 10px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  color: var(--muted);
+  background: rgba(10, 15, 26, 0.78);
+  font-size: 11px;
+}
+
+.language-control select:hover {
+  border-color: var(--line-strong);
+  color: var(--text);
 }
 
 .brand {
@@ -860,6 +892,14 @@ pre {
 @media (max-width: 520px) {
   .brand small {
     display: none;
+  }
+
+  .masthead-actions {
+    gap: 9px;
+  }
+
+  .language-control select {
+    max-width: 104px;
   }
 
   .login-panel {

--- a/internal/server/dashboard/dashboard.js
+++ b/internal/server/dashboard/dashboard.js
@@ -3,7 +3,185 @@
 (() => {
   "use strict";
 
+  const translations = {
+    en: {
+      "brand.homeAria": "Error-Tracer home",
+      "brand.tagline": "browser failure observatory",
+      "language.label": "Language",
+      "connection.connected": "Connected",
+      "connection.demo": "Read-only demo",
+      "login.eyebrow": "Private control plane",
+      "login.title": "See the failures your users cannot explain.",
+      "login.body": "Connect with the admin token configured on this Error-Tracer instance. The token stays in this tab's memory and is never persisted.",
+      "login.tokenLabel": "Admin token",
+      "login.tokenPlaceholder": "Paste a 24+ character token",
+      "login.connect": "Connect",
+      "login.demo": "Explore the read-only demo",
+      "login.noCredentials": "No credentials are stored by the dashboard.",
+      "login.tokenTooShort": "The admin token must contain at least 24 characters.",
+      "login.connecting": "Connecting…",
+      "login.loadingDemo": "Loading the read-only demo…",
+      "login.disconnected": "Disconnected. Paste the admin token to reconnect.",
+      "login.tokenChanged": "The admin token was rejected or has changed.",
+      "login.tokenRejected": "The admin token was rejected.",
+      "workspace.aria": "Issue dashboard",
+      "workspace.eyebrow": "Issue stream",
+      "workspace.title": "Failures, grouped by root signal.",
+      "workspace.refresh": "Refresh",
+      "workspace.disconnect": "Disconnect",
+      "workspace.readOnly": "The demo is read-only. Connect with an admin token to change issue status.",
+      "demo.title": "Demo workspace",
+      "demo.body": "Built-in sample events only. The live database and management API remain private.",
+      "metrics.aria": "Current page summary",
+      "metrics.matching": "Matching issues",
+      "metrics.occurrences": "Page occurrences",
+      "metrics.latest": "Latest signal",
+      "metrics.quiet": "Quiet",
+      "issues.title": "Issues",
+      "issues.waiting": "Waiting for data",
+      "issues.status": "Status",
+      "issues.columnIssue": "Issue",
+      "issues.columnStatus": "Status",
+      "issues.columnEvents": "Events",
+      "issues.columnLastSeen": "Last seen",
+      "issues.emptyTitle": "No matching issues",
+      "issues.emptyBody": "The quiet is real—for this filter, at least.",
+      "issues.pageInitial": "Page 1",
+      "issues.previous": "Previous",
+      "issues.next": "Next",
+      "issues.showing": "Showing {start}–{end} of {total}",
+      "issues.noResults": "No issues match this view",
+      "issues.page": "Page {page}",
+      "status.all": "All",
+      "status.open": "Open",
+      "status.resolved": "Resolved",
+      "status.ignored": "Ignored",
+      "detail.kind": "Issue detail",
+      "detail.loading": "Loading…",
+      "detail.close": "Close issue detail",
+      "detail.location": "Location",
+      "detail.latestStack": "Latest stack",
+      "detail.noStack": "No stack was captured.",
+      "detail.context": "Context",
+      "detail.setStatus": "Set status",
+      "detail.event": "{count} event",
+      "detail.events": "{count} events",
+      "detail.first": "First {time}",
+      "detail.last": "Last {time}",
+      "detail.page": "Page",
+      "detail.release": "Release",
+      "detail.environment": "Environment",
+      "detail.userAgent": "User agent",
+      "detail.occurred": "Occurred",
+      "detail.eventID": "Event ID",
+      "detail.tags": "Tags",
+      "kind.error": "error",
+      "kind.unhandled_rejection": "unhandled rejection",
+      "kind.resource_error": "resource error",
+      "location.unknownSource": "Unknown source",
+      "time.unknown": "Unknown time",
+      "time.unknownShort": "Unknown",
+      "errors.unreachable": "Cannot reach Error-Tracer. Check the service and try again.",
+      "errors.adminUnavailable": "The management API is not configured.",
+      "errors.issueNotFound": "That issue no longer exists.",
+      "errors.invalidPagination": "The requested issue page is invalid.",
+      "errors.invalidStatus": "That issue status is not supported.",
+      "errors.demoUnavailable": "The demo is no longer available on this instance.",
+      "errors.internal": "Error-Tracer could not complete the request.",
+      "errors.http": "Error-Tracer returned HTTP {status}.",
+      "errors.generic": "Something went wrong. Try again.",
+    },
+    "zh-CN": {
+      "brand.homeAria": "Error-Tracer 首页",
+      "brand.tagline": "浏览器错误观测台",
+      "language.label": "语言",
+      "connection.connected": "已连接",
+      "connection.demo": "只读演示",
+      "login.eyebrow": "私有控制台",
+      "login.title": "看见用户难以描述的故障。",
+      "login.body": "使用当前 Error-Tracer 实例配置的管理员令牌连接。令牌只保存在此标签页的内存中，绝不会持久化。",
+      "login.tokenLabel": "管理员令牌",
+      "login.tokenPlaceholder": "粘贴至少 24 个字符的令牌",
+      "login.connect": "连接",
+      "login.demo": "查看只读演示",
+      "login.noCredentials": "Dashboard 不会保存任何凭据。",
+      "login.tokenTooShort": "管理员令牌必须至少包含 24 个字符。",
+      "login.connecting": "正在连接…",
+      "login.loadingDemo": "正在加载只读演示…",
+      "login.disconnected": "已断开。粘贴管理员令牌可重新连接。",
+      "login.tokenChanged": "管理员令牌被拒绝或已发生变更。",
+      "login.tokenRejected": "管理员令牌被拒绝。",
+      "workspace.aria": "问题 Dashboard",
+      "workspace.eyebrow": "问题流",
+      "workspace.title": "按根信号聚合故障。",
+      "workspace.refresh": "刷新",
+      "workspace.disconnect": "断开连接",
+      "workspace.readOnly": "演示模式为只读。请使用管理员令牌连接后再修改问题状态。",
+      "demo.title": "演示工作区",
+      "demo.body": "这里只显示内置样例事件，真实数据库和管理 API 保持私有。",
+      "metrics.aria": "当前页面摘要",
+      "metrics.matching": "匹配的问题",
+      "metrics.occurrences": "本页发生次数",
+      "metrics.latest": "最新信号",
+      "metrics.quiet": "暂无信号",
+      "issues.title": "问题",
+      "issues.waiting": "等待数据",
+      "issues.status": "状态",
+      "issues.columnIssue": "问题",
+      "issues.columnStatus": "状态",
+      "issues.columnEvents": "事件数",
+      "issues.columnLastSeen": "最后出现",
+      "issues.emptyTitle": "没有匹配的问题",
+      "issues.emptyBody": "至少在当前筛选条件下，一切安静。",
+      "issues.pageInitial": "第 1 页",
+      "issues.previous": "上一页",
+      "issues.next": "下一页",
+      "issues.showing": "显示第 {start}–{end} 项，共 {total} 项",
+      "issues.noResults": "当前视图没有匹配的问题",
+      "issues.page": "第 {page} 页",
+      "status.all": "全部",
+      "status.open": "待处理",
+      "status.resolved": "已解决",
+      "status.ignored": "已忽略",
+      "detail.kind": "问题详情",
+      "detail.loading": "正在加载…",
+      "detail.close": "关闭问题详情",
+      "detail.location": "位置",
+      "detail.latestStack": "最新堆栈",
+      "detail.noStack": "没有捕获到堆栈。",
+      "detail.context": "上下文",
+      "detail.setStatus": "设置状态",
+      "detail.event": "{count} 个事件",
+      "detail.events": "{count} 个事件",
+      "detail.first": "首次：{time}",
+      "detail.last": "最近：{time}",
+      "detail.page": "页面",
+      "detail.release": "版本",
+      "detail.environment": "环境",
+      "detail.userAgent": "用户代理",
+      "detail.occurred": "发生时间",
+      "detail.eventID": "事件 ID",
+      "detail.tags": "标签",
+      "kind.error": "错误",
+      "kind.unhandled_rejection": "未处理的 Promise 拒绝",
+      "kind.resource_error": "资源加载错误",
+      "location.unknownSource": "未知来源",
+      "time.unknown": "未知时间",
+      "time.unknownShort": "未知",
+      "errors.unreachable": "无法连接 Error-Tracer，请检查服务后重试。",
+      "errors.adminUnavailable": "管理 API 尚未配置。",
+      "errors.issueNotFound": "该问题已不存在。",
+      "errors.invalidPagination": "请求的问题页面无效。",
+      "errors.invalidStatus": "不支持该问题状态。",
+      "errors.demoUnavailable": "此实例已不再提供演示模式。",
+      "errors.internal": "Error-Tracer 无法完成请求。",
+      "errors.http": "Error-Tracer 返回了 HTTP {status}。",
+      "errors.generic": "出现错误，请重试。",
+    },
+  };
+
   const elements = {
+    language: document.querySelector("#language-select"),
     connection: document.querySelector("#connection-status"),
     connectionLabel: document.querySelector("#connection-label"),
     loginPanel: document.querySelector("#login-panel"),
@@ -38,6 +216,7 @@
   };
 
   const state = {
+    language: detectLanguage(),
     token: "",
     demo: false,
     status: "",
@@ -48,30 +227,34 @@
     loading: false,
   };
 
-  const integerFormat = new Intl.NumberFormat();
-  const dateFormat = new Intl.DateTimeFormat(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short",
+  const messageRenderers = new Map();
+  let integerFormat;
+  let dateFormat;
+  let relativeFormat;
+
+  elements.language.addEventListener("change", () => {
+    setLanguage(elements.language.value, true);
   });
 
   elements.tokenForm.addEventListener("submit", async (event) => {
     event.preventDefault();
     const token = elements.tokenInput.value.trim();
     if (token.length < 24) {
-      showMessage(elements.loginMessage, "The admin token must contain at least 24 characters.", true);
+      showMessage(elements.loginMessage, message("login.tokenTooShort"), true);
       return;
     }
+    state.demo = false;
     state.token = token;
     state.offset = 0;
     setLoginBusy(true);
-    showMessage(elements.loginMessage, "Connecting…", false);
+    showMessage(elements.loginMessage, message("login.connecting"), false);
     try {
       await loadIssues();
       elements.tokenInput.value = "";
       showWorkspace();
     } catch (error) {
       state.token = "";
-      showMessage(elements.loginMessage, readableError(error), true);
+      showMessage(elements.loginMessage, () => readableError(error), true);
       elements.tokenInput.focus();
     } finally {
       setLoginBusy(false);
@@ -79,16 +262,17 @@
   });
 
   elements.demo.addEventListener("click", async () => {
+    state.token = "";
     state.demo = true;
     state.offset = 0;
     setLoginBusy(true);
-    showMessage(elements.loginMessage, "Loading the read-only demo…", false);
+    showMessage(elements.loginMessage, message("login.loadingDemo"), false);
     try {
       await loadIssues();
       showWorkspace();
     } catch (error) {
       state.demo = false;
-      showMessage(elements.loginMessage, readableError(error), true);
+      showMessage(elements.loginMessage, () => readableError(error), true);
     } finally {
       setLoginBusy(false);
     }
@@ -99,7 +283,7 @@
   });
 
   elements.logout.addEventListener("click", () => {
-    disconnect("Disconnected. Paste the admin token to reconnect.");
+    disconnect("login.disconnected");
   });
 
   elements.statusFilter.addEventListener("change", () => {
@@ -146,7 +330,7 @@
     }
     state.loading = true;
     setWorkspaceBusy(true);
-    showMessage(elements.workspaceMessage, "", false);
+    showMessage(elements.workspaceMessage, () => "", false);
     try {
       const query = new URLSearchParams({
         limit: String(state.limit),
@@ -187,7 +371,7 @@
       return;
     }
     if (state.demo) {
-      showMessage(elements.workspaceMessage, "The demo is read-only. Connect with an admin token to change issue status.", false);
+      showMessage(elements.workspaceMessage, message("workspace.readOnly"), false);
       return;
     }
     setStatusButtonsBusy(true);
@@ -206,9 +390,7 @@
 
   async function requestJSON(path, options) {
     options = options || {};
-    const headers = {
-      Accept: "application/json",
-    };
+    const headers = { Accept: "application/json" };
     if (!state.demo) {
       headers.Authorization = `Bearer ${state.token}`;
     }
@@ -229,16 +411,16 @@
         headers,
       });
     } catch (_) {
-      throw new Error("Cannot reach Error-Tracer. Check the service and try again.");
+      throw dashboardError("errors.unreachable");
     }
 
     const payload = await response.json().catch(() => ({}));
     if (response.status === 401 && !state.demo) {
-      disconnect("The admin token was rejected or has changed.");
-      throw new Error("The admin token was rejected.");
+      disconnect("login.tokenChanged");
+      throw dashboardError("login.tokenRejected");
     }
     if (!response.ok) {
-      throw new Error(errorLabel(payload.error, response.status));
+      throw dashboardError(errorKey(payload.error), { status: response.status });
     }
     return payload;
   }
@@ -251,14 +433,22 @@
     elements.metricOccurrences.textContent = integerFormat.format(
       issues.reduce((total, issue) => total + Number(issue.occurrences || 0), 0),
     );
-    elements.metricLatest.textContent = issues.length ? relativeTime(issues[0].last_seen) : "Quiet";
+    elements.metricLatest.textContent = issues.length
+      ? relativeTime(issues[0].last_seen)
+      : t("metrics.quiet");
 
     const start = page.total ? state.offset + 1 : 0;
     const end = Math.min(state.offset + issues.length, page.total || 0);
     elements.resultCopy.textContent = page.total
-      ? `Showing ${integerFormat.format(start)}–${integerFormat.format(end)} of ${integerFormat.format(page.total)}`
-      : "No issues match this view";
-    elements.pageCopy.textContent = `Page ${Math.floor(state.offset / state.limit) + 1}`;
+      ? t("issues.showing", {
+        start: integerFormat.format(start),
+        end: integerFormat.format(end),
+        total: integerFormat.format(page.total),
+      })
+      : t("issues.noResults");
+    elements.pageCopy.textContent = t("issues.page", {
+      page: integerFormat.format(Math.floor(state.offset / state.limit) + 1),
+    });
     elements.previous.disabled = state.offset === 0;
     elements.next.disabled = state.offset + state.limit >= (page.total || 0);
   }
@@ -279,7 +469,7 @@
     const statusCell = document.createElement("td");
     const badge = document.createElement("span");
     badge.className = `badge badge-${safeStatus(issue.status)}`;
-    badge.textContent = safeStatus(issue.status);
+    badge.textContent = statusLabel(issue.status);
     statusCell.append(badge);
 
     const occurrencesCell = document.createElement("td");
@@ -297,26 +487,32 @@
 
   function renderDetail(issue) {
     const latest = issue.last_event || {};
+    const count = Number(issue.occurrences || 0);
     elements.detailKind.textContent = kindLabel(issue.kind);
     elements.detailTitle.textContent = issue.message || kindLabel(issue.kind);
     elements.detailMeta.replaceChildren(
-      detailMeta(`${integerFormat.format(Number(issue.occurrences || 0))} events`),
-      detailMeta(`First ${absoluteTime(issue.first_seen)}`),
-      detailMeta(`Last ${absoluteTime(issue.last_seen)}`),
+      detailMeta(t(count === 1 ? "detail.event" : "detail.events", {
+        count: integerFormat.format(count),
+      })),
+      detailMeta(t("detail.first", { time: absoluteTime(issue.first_seen) })),
+      detailMeta(t("detail.last", { time: absoluteTime(issue.last_seen) })),
       statusBadge(issue.status),
     );
     elements.detailLocation.textContent = locationLabel(issue);
-    elements.detailStack.textContent = latest.stack || "No stack was captured.";
+    elements.detailStack.textContent = latest.stack || t("detail.noStack");
     elements.detailContext.replaceChildren();
-    appendContext("Page", latest.page_url);
-    appendContext("Release", latest.release);
-    appendContext("Environment", latest.environment);
-    appendContext("User agent", latest.user_agent);
-    appendContext("Occurred", latest.occurred_at ? absoluteTime(latest.occurred_at) : "");
-    appendContext("Event ID", latest.id);
+    appendContext(t("detail.page"), latest.page_url);
+    appendContext(t("detail.release"), latest.release);
+    appendContext(t("detail.environment"), latest.environment);
+    appendContext(t("detail.userAgent"), latest.user_agent);
+    appendContext(
+      t("detail.occurred"),
+      latest.occurred_at ? absoluteTime(latest.occurred_at) : "",
+    );
+    appendContext(t("detail.eventID"), latest.id);
     if (latest.tags && typeof latest.tags === "object") {
       appendContext(
-        "Tags",
+        t("detail.tags"),
         Object.entries(latest.tags).map(([key, value]) => `${key}=${value}`).join(", "),
       );
     }
@@ -344,7 +540,7 @@
   }
 
   function statusBadge(status) {
-    const badge = detailMeta(safeStatus(status));
+    const badge = detailMeta(statusLabel(status));
     badge.className = `badge badge-${safeStatus(status)}`;
     return badge;
   }
@@ -354,23 +550,26 @@
     elements.workspace.hidden = false;
     elements.connection.hidden = false;
     elements.demoBanner.hidden = !state.demo;
-    elements.connectionLabel.textContent = state.demo ? "Read-only demo" : "Connected";
-    showMessage(elements.loginMessage, "No credentials are stored by the dashboard.", false);
+    updateConnectionLabel();
+    showMessage(elements.loginMessage, message("login.noCredentials"), false);
   }
 
-  function disconnect(message) {
+  function disconnect(messageKey) {
     state.token = "";
     state.demo = false;
+    state.status = "";
+    state.offset = 0;
     state.page = null;
     state.selected = null;
     closeIssueDialog();
     elements.workspace.hidden = true;
     elements.connection.hidden = true;
     elements.demoBanner.hidden = true;
-    elements.connectionLabel.textContent = "Connected";
+    elements.statusFilter.value = "";
+    updateConnectionLabel();
     elements.loginPanel.hidden = false;
     elements.tokenInput.value = "";
-    showMessage(elements.loginMessage, message, false);
+    showMessage(elements.loginMessage, message(messageKey), false);
     elements.tokenInput.focus();
   }
 
@@ -383,12 +582,28 @@
   }
 
   function showWorkspaceError(error) {
-    showMessage(elements.workspaceMessage, readableError(error), true);
+    showMessage(elements.workspaceMessage, () => readableError(error), true);
   }
 
-  function showMessage(element, message, isError) {
-    element.textContent = message;
+  function message(key, values) {
+    return () => t(key, values);
+  }
+
+  function showMessage(element, renderer, isError) {
+    const safeRenderer = typeof renderer === "function" ? renderer : () => String(renderer);
+    messageRenderers.set(element, { renderer: safeRenderer, isError: Boolean(isError) });
+    renderMessage(element, safeRenderer, isError);
+  }
+
+  function renderMessage(element, renderer, isError) {
+    element.textContent = renderer();
     element.dataset.error = String(Boolean(isError));
+  }
+
+  function refreshMessages() {
+    for (const [element, rendered] of messageRenderers) {
+      renderMessage(element, rendered.renderer, rendered.isError);
+    }
   }
 
   function setLoginBusy(busy) {
@@ -413,58 +628,166 @@
   }
 
   function locationLabel(issue) {
-    const source = issue.source_url || "Unknown source";
+    const source = issue.source_url || t("location.unknownSource");
     const line = Number(issue.line || 0);
     const column = Number(issue.column || 0);
     return line ? `${source}:${line}${column ? `:${column}` : ""}` : source;
   }
 
   function kindLabel(kind) {
-    return String(kind || "error").replaceAll("_", " ");
+    const supported = ["error", "unhandled_rejection", "resource_error"];
+    return t(`kind.${supported.includes(kind) ? kind : "error"}`);
   }
 
   function safeStatus(status) {
     return ["open", "resolved", "ignored"].includes(status) ? status : "open";
   }
 
+  function statusLabel(status) {
+    return t(`status.${safeStatus(status)}`);
+  }
+
   function absoluteTime(value) {
     const date = new Date(value);
-    return Number.isNaN(date.getTime()) ? "Unknown time" : dateFormat.format(date);
+    return Number.isNaN(date.getTime()) ? t("time.unknown") : dateFormat.format(date);
   }
 
   function relativeTime(value) {
     const date = new Date(value);
     if (Number.isNaN(date.getTime())) {
-      return "Unknown";
+      return t("time.unknownShort");
     }
     const seconds = Math.round((date.getTime() - Date.now()) / 1000);
     const magnitude = Math.abs(seconds);
-    const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
     if (magnitude < 60) {
-      return formatter.format(seconds, "second");
+      return relativeFormat.format(seconds, "second");
     }
     if (magnitude < 3600) {
-      return formatter.format(Math.round(seconds / 60), "minute");
+      return relativeFormat.format(Math.round(seconds / 60), "minute");
     }
     if (magnitude < 86_400) {
-      return formatter.format(Math.round(seconds / 3600), "hour");
+      return relativeFormat.format(Math.round(seconds / 3600), "hour");
     }
-    return formatter.format(Math.round(seconds / 86_400), "day");
+    return relativeFormat.format(Math.round(seconds / 86_400), "day");
   }
 
-  function errorLabel(code, status) {
+  function errorKey(code) {
     const labels = {
-      admin_unavailable: "The management API is not configured.",
-      issue_not_found: "That issue no longer exists.",
-      invalid_pagination: "The requested issue page is invalid.",
-      invalid_status: "That issue status is not supported.",
-      internal_error: "Error-Tracer could not complete the request.",
+      admin_unavailable: "errors.adminUnavailable",
+      issue_not_found: "errors.issueNotFound",
+      invalid_pagination: "errors.invalidPagination",
+      invalid_status: "errors.invalidStatus",
+      demo_unavailable: "errors.demoUnavailable",
+      internal_error: "errors.internal",
     };
-    return labels[code] || `Error-Tracer returned HTTP ${status}.`;
+    return labels[code] || "errors.http";
+  }
+
+  function dashboardError(key, values) {
+    const error = new Error(key);
+    error.translationKey = key;
+    error.translationValues = values;
+    return error;
   }
 
   function readableError(error) {
-    return error && error.message ? error.message : "Something went wrong. Try again.";
+    if (error && error.translationKey) {
+      return t(error.translationKey, error.translationValues);
+    }
+    return t("errors.generic");
+  }
+
+  function detectLanguage() {
+    const requested = new URLSearchParams(window.location.search).get("lang");
+    const fromQuery = supportedLanguage(requested);
+    if (fromQuery) {
+      return fromQuery;
+    }
+    const browserLanguages = Array.isArray(navigator.languages)
+      ? navigator.languages
+      : [navigator.language];
+    for (const language of browserLanguages) {
+      const supported = supportedLanguage(language);
+      if (supported) {
+        return supported;
+      }
+    }
+    return "en";
+  }
+
+  function supportedLanguage(language) {
+    const normalized = String(language || "").toLowerCase();
+    if (normalized === "en" || normalized.startsWith("en-")) {
+      return "en";
+    }
+    if (normalized === "zh" || normalized === "zh-cn" || normalized === "zh-sg" ||
+        normalized.startsWith("zh-hans")) {
+      return "zh-CN";
+    }
+    return "";
+  }
+
+  function setLanguage(language, updateURL) {
+    state.language = supportedLanguage(language) || "en";
+    if (updateURL) {
+      try {
+        const currentURL = new URL(window.location.href);
+        currentURL.searchParams.set("lang", state.language);
+        window.history.replaceState(null, "", currentURL);
+      } catch (_) {
+        // The dashboard still switches languages when history is unavailable.
+      }
+    }
+    configureFormatters();
+    applyTranslations();
+  }
+
+  function configureFormatters() {
+    integerFormat = new Intl.NumberFormat(state.language);
+    dateFormat = new Intl.DateTimeFormat(state.language, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
+    relativeFormat = new Intl.RelativeTimeFormat(state.language, { numeric: "auto" });
+  }
+
+  function applyTranslations() {
+    document.documentElement.lang = state.language;
+    elements.language.value = state.language;
+    for (const element of document.querySelectorAll("[data-i18n]")) {
+      element.textContent = t(element.dataset.i18n);
+    }
+    for (const element of document.querySelectorAll("[data-i18n-placeholder]")) {
+      element.setAttribute("placeholder", t(element.dataset.i18nPlaceholder));
+    }
+    for (const element of document.querySelectorAll("[data-i18n-aria-label]")) {
+      element.setAttribute("aria-label", t(element.dataset.i18nAriaLabel));
+    }
+    updateConnectionLabel();
+    refreshMessages();
+    if (state.page) {
+      renderPage(state.page);
+    }
+    if (state.selected) {
+      renderDetail(state.selected);
+    }
+  }
+
+  function updateConnectionLabel() {
+    elements.connectionLabel.textContent = t(
+      state.demo ? "connection.demo" : "connection.connected",
+    );
+  }
+
+  function t(key, values) {
+    const table = translations[state.language] || translations.en;
+    const template = table[key] || translations.en[key] || key;
+    return template.replace(/\{([a-zA-Z0-9_]+)\}/g, (_, name) => {
+      if (!values || values[name] === undefined || values[name] === null) {
+        return `{${name}}`;
+      }
+      return String(values[name]);
+    });
   }
 
   async function discoverDemo() {
@@ -483,5 +806,8 @@
     }
   }
 
+  configureFormatters();
+  applyTranslations();
+  showMessage(elements.loginMessage, message("login.noCredentials"), false);
   discoverDemo();
 })();

--- a/internal/server/dashboard/index.html
+++ b/internal/server/dashboard/index.html
@@ -15,66 +15,75 @@
 
   <main class="shell">
     <header class="masthead">
-      <a class="brand" href="/" aria-label="Error-Tracer home">
+      <a class="brand" href="/" aria-label="Error-Tracer home" data-i18n-aria-label="brand.homeAria">
         <span class="brand-mark" aria-hidden="true"><i></i><i></i><i></i></span>
         <span>
           <strong>Error-Tracer</strong>
-          <small>browser failure observatory</small>
+          <small data-i18n="brand.tagline">browser failure observatory</small>
         </span>
       </a>
-      <div class="connection" id="connection-status" hidden>
-        <span class="pulse" aria-hidden="true"></span>
-        <span id="connection-label">Connected</span>
+      <div class="masthead-actions">
+        <label class="language-control" for="language-select">
+          <span class="visually-hidden" data-i18n="language.label">Language</span>
+          <select id="language-select" aria-label="Language" data-i18n-aria-label="language.label">
+            <option value="en">English</option>
+            <option value="zh-CN">简体中文</option>
+          </select>
+        </label>
+        <div class="connection" id="connection-status" hidden>
+          <span class="pulse" aria-hidden="true"></span>
+          <span id="connection-label">Connected</span>
+        </div>
       </div>
     </header>
 
     <section class="login-panel" id="login-panel" aria-labelledby="login-title">
       <div class="login-copy">
-        <p class="eyebrow">Private control plane</p>
-        <h1 id="login-title">See the failures your users cannot explain.</h1>
-        <p>Connect with the admin token configured on this Error-Tracer instance. The token stays in this tab's memory and is never persisted.</p>
+        <p class="eyebrow" data-i18n="login.eyebrow">Private control plane</p>
+        <h1 id="login-title" data-i18n="login.title">See the failures your users cannot explain.</h1>
+        <p data-i18n="login.body">Connect with the admin token configured on this Error-Tracer instance. The token stays in this tab's memory and is never persisted.</p>
       </div>
       <form class="token-form" id="token-form">
-        <label for="admin-token">Admin token</label>
+        <label for="admin-token" data-i18n="login.tokenLabel">Admin token</label>
         <div class="token-row">
           <input id="admin-token" name="admin-token" type="password" required minlength="24"
                  autocomplete="off" autocapitalize="none" spellcheck="false"
-                 placeholder="Paste a 24+ character token">
-          <button class="button button-primary" type="submit">Connect</button>
+                 placeholder="Paste a 24+ character token" data-i18n-placeholder="login.tokenPlaceholder">
+          <button class="button button-primary" type="submit" data-i18n="login.connect">Connect</button>
         </div>
-        <button class="button button-demo" id="demo-button" type="button" hidden>Explore the read-only demo</button>
-        <p class="form-note" id="login-message" role="status">No credentials are stored by the dashboard.</p>
+        <button class="button button-demo" id="demo-button" type="button" hidden data-i18n="login.demo">Explore the read-only demo</button>
+        <p class="form-note" id="login-message" role="status" data-i18n="login.noCredentials">No credentials are stored by the dashboard.</p>
       </form>
     </section>
 
-    <section class="workspace" id="workspace" hidden aria-label="Issue dashboard">
+    <section class="workspace" id="workspace" hidden aria-label="Issue dashboard" data-i18n-aria-label="workspace.aria">
       <div class="workspace-heading">
         <div>
-          <p class="eyebrow">Issue stream</p>
-          <h1>Failures, grouped by root signal.</h1>
+          <p class="eyebrow" data-i18n="workspace.eyebrow">Issue stream</p>
+          <h1 data-i18n="workspace.title">Failures, grouped by root signal.</h1>
         </div>
         <div class="header-actions">
-          <button class="button button-quiet" id="refresh-button" type="button">Refresh</button>
-          <button class="button button-quiet" id="logout-button" type="button">Disconnect</button>
+          <button class="button button-quiet" id="refresh-button" type="button" data-i18n="workspace.refresh">Refresh</button>
+          <button class="button button-quiet" id="logout-button" type="button" data-i18n="workspace.disconnect">Disconnect</button>
         </div>
       </div>
 
       <aside class="demo-banner" id="demo-banner" hidden>
-        <strong>Demo workspace</strong>
-        <span>Built-in sample events only. The live database and management API remain private.</span>
+        <strong data-i18n="demo.title">Demo workspace</strong>
+        <span data-i18n="demo.body">Built-in sample events only. The live database and management API remain private.</span>
       </aside>
 
-      <section class="metrics" aria-label="Current page summary">
+      <section class="metrics" aria-label="Current page summary" data-i18n-aria-label="metrics.aria">
         <article>
-          <span>Matching issues</span>
+          <span data-i18n="metrics.matching">Matching issues</span>
           <strong id="metric-total">—</strong>
         </article>
         <article>
-          <span>Page occurrences</span>
+          <span data-i18n="metrics.occurrences">Page occurrences</span>
           <strong id="metric-occurrences">—</strong>
         </article>
         <article>
-          <span>Latest signal</span>
+          <span data-i18n="metrics.latest">Latest signal</span>
           <strong id="metric-latest">—</strong>
         </article>
       </section>
@@ -82,16 +91,16 @@
       <section class="issue-panel" aria-labelledby="issues-title">
         <div class="panel-toolbar">
           <div>
-            <h2 id="issues-title">Issues</h2>
-            <p id="result-copy">Waiting for data</p>
+            <h2 id="issues-title" data-i18n="issues.title">Issues</h2>
+            <p id="result-copy" data-i18n="issues.waiting">Waiting for data</p>
           </div>
           <label class="filter">
-            <span>Status</span>
+            <span data-i18n="issues.status">Status</span>
             <select id="status-filter">
-              <option value="">All</option>
-              <option value="open">Open</option>
-              <option value="resolved">Resolved</option>
-              <option value="ignored">Ignored</option>
+              <option value="" data-i18n="status.all">All</option>
+              <option value="open" data-i18n="status.open">Open</option>
+              <option value="resolved" data-i18n="status.resolved">Resolved</option>
+              <option value="ignored" data-i18n="status.ignored">Ignored</option>
             </select>
           </label>
         </div>
@@ -100,26 +109,26 @@
           <table>
             <thead>
               <tr>
-                <th scope="col">Issue</th>
-                <th scope="col">Status</th>
-                <th scope="col">Events</th>
-                <th scope="col">Last seen</th>
+                <th scope="col" data-i18n="issues.columnIssue">Issue</th>
+                <th scope="col" data-i18n="issues.columnStatus">Status</th>
+                <th scope="col" data-i18n="issues.columnEvents">Events</th>
+                <th scope="col" data-i18n="issues.columnLastSeen">Last seen</th>
               </tr>
             </thead>
             <tbody id="issue-list"></tbody>
           </table>
           <div class="empty-state" id="empty-state" hidden>
             <span aria-hidden="true">✓</span>
-            <strong>No matching issues</strong>
-            <p>The quiet is real—for this filter, at least.</p>
+            <strong data-i18n="issues.emptyTitle">No matching issues</strong>
+            <p data-i18n="issues.emptyBody">The quiet is real—for this filter, at least.</p>
           </div>
         </div>
 
         <footer class="pagination">
-          <span id="page-copy">Page 1</span>
+          <span id="page-copy" data-i18n="issues.pageInitial">Page 1</span>
           <div>
-            <button class="button button-quiet" id="previous-button" type="button">Previous</button>
-            <button class="button button-quiet" id="next-button" type="button">Next</button>
+            <button class="button button-quiet" id="previous-button" type="button" data-i18n="issues.previous">Previous</button>
+            <button class="button button-quiet" id="next-button" type="button" data-i18n="issues.next">Next</button>
           </div>
         </footer>
       </section>
@@ -131,30 +140,30 @@
     <div class="dialog-shell">
       <header>
         <div>
-          <p class="eyebrow" id="detail-kind">Issue detail</p>
-          <h2 id="detail-title">Loading…</h2>
+          <p class="eyebrow" id="detail-kind" data-i18n="detail.kind">Issue detail</p>
+          <h2 id="detail-title" data-i18n="detail.loading">Loading…</h2>
         </div>
-        <button class="icon-button" id="close-dialog" type="button" aria-label="Close issue detail">×</button>
+        <button class="icon-button" id="close-dialog" type="button" aria-label="Close issue detail" data-i18n-aria-label="detail.close">×</button>
       </header>
       <div class="detail-meta" id="detail-meta"></div>
       <section class="detail-section">
-        <h3>Location</h3>
+        <h3 data-i18n="detail.location">Location</h3>
         <p class="code-line" id="detail-location">—</p>
       </section>
       <section class="detail-section">
-        <h3>Latest stack</h3>
-        <pre id="detail-stack">No stack was captured.</pre>
+        <h3 data-i18n="detail.latestStack">Latest stack</h3>
+        <pre id="detail-stack" data-i18n="detail.noStack">No stack was captured.</pre>
       </section>
       <section class="detail-section">
-        <h3>Context</h3>
+        <h3 data-i18n="detail.context">Context</h3>
         <dl class="context-grid" id="detail-context"></dl>
       </section>
       <footer>
-        <span>Set status</span>
+        <span data-i18n="detail.setStatus">Set status</span>
         <div class="status-actions" id="status-actions">
-          <button class="status-button" data-status="open" type="button">Open</button>
-          <button class="status-button" data-status="resolved" type="button">Resolved</button>
-          <button class="status-button" data-status="ignored" type="button">Ignored</button>
+          <button class="status-button" data-status="open" type="button" data-i18n="status.open">Open</button>
+          <button class="status-button" data-status="resolved" type="button" data-i18n="status.resolved">Resolved</button>
+          <button class="status-button" data-status="ignored" type="button" data-i18n="status.ignored">Ignored</button>
         </div>
       </footer>
     </div>

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -20,6 +21,7 @@ func TestDashboardIndex(t *testing.T) {
 	for _, marker := range []string{
 		"<title>Error-Tracer</title>",
 		`id="token-form"`,
+		`id="language-select"`,
 		`id="demo-button"`,
 		`id="demo-banner"`,
 		`id="issue-list"`,
@@ -122,6 +124,60 @@ func TestDashboardScriptAvoidsCredentialPersistenceAndHTMLInjection(t *testing.T
 	for _, marker := range []string{"/api/v1/meta", "/api/v1/demo/issues"} {
 		if !strings.Contains(dashboardScript.body, marker) {
 			t.Fatalf("dashboard script does not contain demo marker %q", marker)
+		}
+	}
+	for _, marker := range []string{
+		`"zh-CN"`,
+		"Intl.RelativeTimeFormat",
+		"history.replaceState",
+		"data-i18n",
+	} {
+		if !strings.Contains(dashboardScript.body, marker) {
+			t.Fatalf("dashboard script does not contain localization marker %q", marker)
+		}
+	}
+}
+
+func TestDashboardTranslationCatalogsStayAligned(t *testing.T) {
+	body := dashboardScript.body
+	englishStart := strings.Index(body, "    en: {")
+	chineseStart := strings.Index(body, "    \"zh-CN\": {")
+	if englishStart < 0 || chineseStart < 0 || chineseStart <= englishStart {
+		t.Fatal("dashboard translation catalogs are missing")
+	}
+	chineseEndOffset := strings.Index(body[chineseStart:], "\n    },\n  };")
+	if chineseEndOffset < 0 {
+		t.Fatal("Simplified Chinese translation catalog is not terminated")
+	}
+
+	keyPattern := regexp.MustCompile(`(?m)^      "([^"]+)":`)
+	keys := func(section string) map[string]bool {
+		result := make(map[string]bool)
+		for _, match := range keyPattern.FindAllStringSubmatch(section, -1) {
+			result[match[1]] = true
+		}
+		return result
+	}
+	english := keys(body[englishStart:chineseStart])
+	chinese := keys(body[chineseStart : chineseStart+chineseEndOffset])
+	if len(english) < 80 || len(chinese) != len(english) {
+		t.Fatalf("translation key counts = en:%d zh-CN:%d", len(english), len(chinese))
+	}
+	for key := range english {
+		if !chinese[key] {
+			t.Errorf("Simplified Chinese catalog is missing %q", key)
+		}
+	}
+	for key := range chinese {
+		if !english[key] {
+			t.Errorf("English catalog is missing %q", key)
+		}
+	}
+
+	attributePattern := regexp.MustCompile(`data-i18n(?:-placeholder|-aria-label)?="([^"]+)"`)
+	for _, match := range attributePattern.FindAllStringSubmatch(dashboardIndex.body, -1) {
+		if !english[match[1]] {
+			t.Errorf("dashboard markup references unknown translation key %q", match[1])
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- add an accessible English / 简体中文 language selector to the embedded dashboard
- localize all static controls, dynamic issue metadata, statuses, error messages, and empty/loading states
- format numbers, dates, and relative times with the selected locale
- initialize from `?lang=` or the browser locale and preserve the choice in the URL only
- re-render the current issue list, open detail, and status messages immediately after a language change

## Security and compatibility

- does not use `localStorage`, `sessionStorage`, cookies, `innerHTML`, or inline scripts/styles
- the admin token remains memory-only
- keeps the existing strict CSP and `textContent`-based rendering
- does not translate user-controlled event content

## Tests

- assert the English and Simplified Chinese catalogs have the same 85 keys
- assert every `data-i18n` markup reference exists
- `node --check internal/server/dashboard/dashboard.js`
- `go test ./...`
- `go vet ./...`
- `npm test`

#33 has merged; this PR now targets `main` and contains localization changes only.