### PR TITLE
docs: refresh setup, demo, localization, and performance guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Error-Tracer
 
+[简体中文](README.zh-CN.md)
+
 Error-Tracer is a small, self-hosted browser error collector. The current
 service is written in Go, stores aggregated issues in SQLite, ships a
 dependency-free browser SDK, and includes an embedded triage dashboard.
@@ -19,9 +21,13 @@ tag. It is not part of the current runtime.
   batch back on failure.
 - Tracks `open`, `resolved`, and `ignored` issue states.
 - Provides an authenticated JSON API and an embedded dashboard.
+- Offers English and Simplified Chinese dashboard locales without browser
+  storage.
+- Includes an opt-in, read-only demo backed only by built-in in-memory data.
 - Enforces request-size limits, exact browser-origin allowlists, per-peer rate
   limits, and constant-time credential comparisons.
 - Runs as a single static binary or a non-root, read-only container.
+- Ships database/application benchmarks and a bounded HTTP load-test command.
 
 ## Quick start with Docker Compose
 
@@ -53,8 +59,14 @@ curl --fail http://localhost:8080/readyz
 Open <http://localhost:8080/> and connect with the admin token. The dashboard
 keeps the token only in the current tab's memory.
 
+Use the language selector or open `/?lang=zh-CN` for Simplified Chinese. The
+selection is reflected in the URL and is not saved to browser storage.
+
 The Compose deployment stores `error-tracer.db` in the named
 `error-tracer-data` volume.
+
+To evaluate the dashboard before ingesting real events, enable the isolated
+read-only demo described in [Demo mode](docs/demo.md).
 
 ## Browser SDK
 
@@ -188,8 +200,11 @@ Pages are limited to 100 issues. Offsets above 100,000 are rejected.
 
 | Method | Path | Authentication | Description |
 | --- | --- | --- | --- |
-| `GET` | `/` | Admin token entered in the page | Embedded dashboard |
+| `GET` | `/` | None | Dashboard shell; live data calls require an admin token |
 | `GET` | `/assets/error-tracer.js` | None | Embedded browser SDK |
+| `GET` | `/api/v1/meta` | None | Public feature metadata; currently only the demo flag |
+| `GET` | `/api/v1/demo/issues` | None, demo mode only | List built-in read-only demo issues |
+| `GET` | `/api/v1/demo/issues/{fingerprint}` | None, demo mode only | Read one built-in demo issue |
 | `POST` | `/api/v1/events` | Ingest key in the body | Submit one event |
 | `POST` | `/api/v1/events/batch` | Ingest key in the body | Submit an atomic batch |
 | `GET` | `/api/v1/issues` | Admin bearer token | List issues |
@@ -210,6 +225,7 @@ Pages are limited to 100 issues. Offsets above 100,000 are rejected.
 | `ERROR_TRACER_ALLOWED_ORIGINS` | No | empty | Comma-separated exact HTTP(S) browser origins |
 | `ERROR_TRACER_RATE_PER_MINUTE` | No | `120` | Ingestion requests per minute per direct peer |
 | `ERROR_TRACER_RATE_BURST` | No | `30` | Maximum token-bucket burst per direct peer |
+| `ERROR_TRACER_DEMO_MODE` | No | `false` | Expose the isolated, public, read-only demo |
 
 `ERROR_TRACER_PORT` is a Compose-only host-port setting and defaults to `8080`.
 An empty origin allowlist disables browser-origin ingestion while still
@@ -228,6 +244,10 @@ go test -race ./...
 npm test
 ```
 
+Performance and capacity checks are opt-in. See
+[Performance and load testing](docs/performance.md) for reproducible commands,
+metric definitions, and load-test safety controls.
+
 Run the service from source:
 
 ```sh
@@ -241,6 +261,12 @@ Build the static service binary:
 ```sh
 CGO_ENABLED=0 go build -trimpath -o error-tracer ./cmd/error-tracer
 ```
+
+## Documentation
+
+- [Demo mode and its security boundary](docs/demo.md)
+- [Performance benchmarks and load testing](docs/performance.md)
+- [Simplified Chinese README](README.zh-CN.md)
 
 ## Deployment notes
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,248 @@
+# Error-Tracer
+
+[English](README.md)
+
+Error-Tracer 是一个轻量、自托管的浏览器错误收集器。当前服务使用 Go
+编写，将聚合后的问题存储在 SQLite 中，并提供零依赖浏览器 SDK 和内嵌的
+问题处理 Dashboard。
+
+2013 年的 PHP/MySQL 原始实现保存在
+[`v1.0.0-legacy`](https://github.com/soulteary/Error-Tracer/tree/v1.0.0-legacy)
+标签中，不属于当前运行时。
+
+## 功能
+
+- 捕获浏览器运行时错误、未处理的 Promise 拒绝和资源加载失败。
+- 持久化之前统一规范事件，并移除 URL 中的凭据、查询参数和片段。
+- 使用稳定的 SHA-256 指纹聚合同类事件。
+- 使用 SQLite 存储问题聚合数据。
+- 在单个事务中原子写入最多 100 个事件，任一步失败都会回滚整批数据。
+- 支持 `open`、`resolved` 和 `ignored` 三种问题状态。
+- 提供带鉴权的 JSON API 和内嵌 Dashboard。
+- Dashboard 支持 English / 简体中文，且不依赖浏览器存储。
+- 提供显式开启、完全隔离真实数据库的公开只读演示模式。
+- 限制请求体大小、浏览器来源、单个对等端速率，并使用常量时间比较凭据。
+- 可构建为单个静态二进制，也可在非 root、只读容器中运行。
+- 自带数据库/程序基准测试和有安全边界的 HTTP 压力测试命令。
+
+## 使用 Docker Compose 快速启动
+
+复制环境变量模板：
+
+```sh
+cp .env.example .env
+```
+
+生成两个彼此独立的随机凭据，并写入 `.env`：
+
+```sh
+openssl rand -hex 16
+openssl rand -hex 24
+```
+
+第一个值可用于 `ERROR_TRACER_INGEST_KEY`，第二个值可用于
+`ERROR_TRACER_ADMIN_TOKEN`。将 `ERROR_TRACER_ALLOWED_ORIGINS` 设置为每个
+允许提交事件的浏览器应用的精确来源，例如 `https://app.example.com`。
+
+启动服务：
+
+```sh
+docker compose up --build -d
+curl --fail http://localhost:8080/readyz
+```
+
+打开 <http://localhost:8080/>，输入管理员令牌连接。Dashboard 只把令牌保留
+在当前标签页的内存中。使用页面上的语言选择器，或直接打开
+`http://localhost:8080/?lang=zh-CN` 切换到简体中文；语言选择只体现在 URL
+中，不会写入浏览器存储。
+
+Compose 使用名为 `error-tracer-data` 的卷保存 `error-tracer.db`。
+
+如果还没有真实事件，可参考[演示模式](docs/demo.md)开启内置只读样例。
+
+## 浏览器 SDK
+
+服务在 `/assets/error-tracer.js` 提供内嵌 SDK：
+
+```html
+<script src="https://errors.example.com/assets/error-tracer.js"></script>
+<script>
+  const tracer = ErrorTracer.init({
+    endpoint: "https://errors.example.com/api/v1/events",
+    projectKey: "替换为采集密钥",
+    release: "web@2026.08.29",
+    environment: "production",
+    tags: { region: "ap-southeast-1" },
+  });
+
+  tracer.captureMessage("checkout started");
+</script>
+```
+
+默认自动捕获错误。如果只需要手动上报，可设置 `autoCapture: false`。客户端还
+支持 `sampleRate`、`maxEventsPerMinute`、`beforeSend` 和自定义 `transport`。
+
+## 采集 API
+
+### 单个事件
+
+`POST /api/v1/events` 接受 JSON，也接受包含 JSON 的 `text/plain`，以便 SDK
+使用 `navigator.sendBeacon`：
+
+```json
+{
+  "project_key": "替换为采集密钥",
+  "event": {
+    "kind": "error",
+    "message": "TypeError: value is not a function",
+    "stack": "TypeError: value is not a function\n    at checkout (app.js:10:2)",
+    "source_url": "https://app.example.com/app.js?build=42",
+    "page_url": "https://app.example.com/checkout?session=secret",
+    "line": 10,
+    "column": 2,
+    "occurred_at": "2026-08-29T14:00:00Z",
+    "release": "web@2026.08.29",
+    "environment": "production",
+    "tags": {
+      "feature": "checkout"
+    }
+  }
+}
+```
+
+服务端会覆盖 `id`、`received_at` 和 `user_agent`。成功时返回
+`202 Accepted`，以及服务端生成的事件 ID 和问题指纹。
+
+### 原子批量写入
+
+`POST /api/v1/events/batch` 接受 1–100 个事件，解码后的请求体最大为
+1 MiB。所有事件都会在修改 SQLite 之前完成规范化和校验，之后的全部
+UPSERT 在同一个事务中执行：
+
+```json
+{
+  "project_key": "替换为采集密钥",
+  "events": [
+    {
+      "kind": "error",
+      "message": "first failure"
+    },
+    {
+      "kind": "unhandled_rejection",
+      "message": "second failure"
+    }
+  ]
+}
+```
+
+响应会按输入顺序返回每个事件的服务端 ID 和指纹。如果校验、UPSERT、
+事务内读回或提交失败，整批数据都不会持久化。
+
+## 问题 API
+
+问题接口要求管理员令牌：
+
+```http
+Authorization: Bearer 替换为管理员令牌
+```
+
+| 方法 | 路径 | 用途 |
+| --- | --- | --- |
+| `GET` | `/api/v1/issues?limit=50&offset=0` | 按最新出现时间列出问题 |
+| `GET` | `/api/v1/issues?status=open` | 按 `open`、`resolved` 或 `ignored` 筛选 |
+| `GET` | `/api/v1/issues/{fingerprint}` | 读取单个问题 |
+| `PATCH` | `/api/v1/issues/{fingerprint}` | 修改问题状态 |
+
+状态修改请求体：
+
+```json
+{
+  "status": "resolved"
+}
+```
+
+每页最多返回 100 个问题，超过 100,000 的偏移量会被拒绝。
+
+## 服务端点
+
+| 方法 | 路径 | 鉴权 | 说明 |
+| --- | --- | --- | --- |
+| `GET` | `/` | 无 | Dashboard 外壳；读取真实数据仍需管理员令牌 |
+| `GET` | `/assets/error-tracer.js` | 无 | 内嵌浏览器 SDK |
+| `GET` | `/api/v1/meta` | 无 | 公开功能元数据，目前仅包含演示开关 |
+| `GET` | `/api/v1/demo/issues` | 无，仅演示模式 | 列出内置只读演示问题 |
+| `GET` | `/api/v1/demo/issues/{fingerprint}` | 无，仅演示模式 | 读取一个内置演示问题 |
+| `POST` | `/api/v1/events` | 请求体中的采集密钥 | 提交单个事件 |
+| `POST` | `/api/v1/events/batch` | 请求体中的采集密钥 | 原子提交一批事件 |
+| `GET` | `/api/v1/issues` | 管理员 Bearer 令牌 | 列出问题 |
+| `GET` | `/api/v1/issues/{fingerprint}` | 管理员 Bearer 令牌 | 读取问题 |
+| `PATCH` | `/api/v1/issues/{fingerprint}` | 管理员 Bearer 令牌 | 更新状态 |
+| `GET` | `/healthz` | 无 | 进程存活状态 |
+| `GET` | `/readyz` | 无 | 是否可以接收新工作 |
+
+## 配置
+
+| 变量 | 必需 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `ERROR_TRACER_ADDRESS` | 否 | `:8080` | HTTP 监听地址 |
+| `ERROR_TRACER_DATABASE_PATH` | 否 | `error-tracer.db` | SQLite 数据库路径 |
+| `ERROR_TRACER_PROJECT_ID` | 否 | `default` | 当前进程拥有的项目命名空间 |
+| `ERROR_TRACER_INGEST_KEY` | 是 | — | 采集凭据，至少 16 字节 |
+| `ERROR_TRACER_ADMIN_TOKEN` | 是 | — | 管理凭据，至少 24 字节 |
+| `ERROR_TRACER_ALLOWED_ORIGINS` | 否 | 空 | 逗号分隔的精确 HTTP(S) 浏览器来源 |
+| `ERROR_TRACER_RATE_PER_MINUTE` | 否 | `120` | 每个直接对等端每分钟允许的采集请求数 |
+| `ERROR_TRACER_RATE_BURST` | 否 | `30` | 令牌桶最大突发量 |
+| `ERROR_TRACER_DEMO_MODE` | 否 | `false` | 开放隔离的公开只读演示 |
+
+`ERROR_TRACER_PORT` 只用于 Compose 的宿主机端口，默认值为 `8080`。来源
+白名单为空时，带 `Origin` 的浏览器采集会被禁用；不发送 `Origin` 的非浏览器
+客户端仍可提交事件。
+
+## 本地开发
+
+模块声明 Go 1.27。仅运行浏览器 SDK 测试时需要 Node.js 22 或更高版本。
+
+```sh
+go mod verify
+go vet ./...
+go test ./...
+go test -race ./...
+npm test
+```
+
+从源码运行：
+
+```sh
+ERROR_TRACER_INGEST_KEY=development-key-1 \
+ERROR_TRACER_ADMIN_TOKEN=development-admin-token-1 \
+go run ./cmd/error-tracer
+```
+
+构建静态服务二进制：
+
+```sh
+CGO_ENABLED=0 go build -trimpath -o error-tracer ./cmd/error-tracer
+```
+
+基准和压力测试不会随普通单测自动运行。完整命令、指标解释和安全限制见
+[性能与压力测试](docs/performance.md)。
+
+## 文档
+
+- [演示模式及其安全边界](docs/demo.md)
+- [性能基准与压力测试](docs/performance.md)
+- [English README](README.md)
+
+## 部署注意事项
+
+- 采集密钥和管理员令牌必须独立、随机生成。
+- 接收网络中的浏览器流量前，应将服务置于 HTTPS 之后。
+- 浏览器来源必须精确配置；系统有意拒绝通配符。
+- 限流器使用直接 TCP 对等端，不信任转发地址请求头。
+- 将 SQLite 路径或 `/data` 卷持久化到容器生命周期之外。
+- 优雅关闭 HTTP 服务前，进程会先将自身标记为未就绪。
+- 不需要公开演示时，保持 `ERROR_TRACER_DEMO_MODE=false`。
+
+## 许可证
+
+Error-Tracer 使用 [Apache License 2.0](LICENSE) 许可证。

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,65 @@
+# Demo mode
+
+Demo mode makes the embedded dashboard useful before a project has submitted
+any real events. It is disabled by default and must be enabled explicitly:
+
+```dotenv
+ERROR_TRACER_DEMO_MODE=true
+```
+
+With Docker Compose, add that value to `.env`, start the service, and open the
+dashboard:
+
+```sh
+docker compose up --build -d
+curl --fail http://localhost:8080/readyz
+```
+
+The sign-in panel then offers **Explore the read-only demo**. The demo includes
+five realistic issues across `open`, `resolved`, and `ignored` states, with 106
+sample occurrences in total. Filtering, pagination, issue details, localized
+dates, and the English/Simplified Chinese UI can be evaluated without an admin
+token.
+
+## Security boundary
+
+The demo is deliberately separate from production data:
+
+- Sample events live in a dedicated in-memory store created at process start.
+- Demo handlers never read from or write to the configured SQLite database.
+- Only `GET` list and detail routes exist under `/api/v1/demo/issues`.
+- The normal `/api/v1/issues` routes still require the admin bearer token.
+- The dashboard disables status changes while the demo is active.
+- `/api/v1/meta` reveals only whether demo mode is enabled.
+
+Because the demo routes are public when enabled, do not put secrets or copied
+production payloads into the built-in fixtures. Disable demo mode on deployments
+that do not need a public product tour.
+
+## Demo endpoints
+
+| Method | Path | Result |
+| --- | --- | --- |
+| `GET` | `/api/v1/meta` | `{"demo_mode":true}` when enabled |
+| `GET` | `/api/v1/demo/issues` | Paginated built-in issue list |
+| `GET` | `/api/v1/demo/issues?status=open` | Built-in issues filtered by status |
+| `GET` | `/api/v1/demo/issues/{fingerprint}` | One built-in issue and its latest event |
+
+The list endpoint accepts the same bounded `limit`, `offset`, and `status`
+parameters as the authenticated issue API. Attempts to `PATCH` a demo issue
+return `405 Method Not Allowed`.
+
+## Language selection
+
+Use the dashboard selector to switch between English and Simplified Chinese, or
+link directly to either locale:
+
+```text
+http://localhost:8080/?lang=en
+http://localhost:8080/?lang=zh-CN
+```
+
+The language is initialized from the URL or compatible browser locale. The
+selector updates the URL with `history.replaceState`; it does not use local
+storage, session storage, or cookies. Event messages, stack traces, URLs, and
+tags are user-controlled data and are intentionally not translated.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,122 @@
+# Performance and load testing
+
+Error-Tracer includes repeatable Go benchmarks for storage and HTTP processing,
+plus a dependency-free command for end-to-end pressure tests. Benchmarks are not
+part of the normal unit-test run and must be invoked explicitly.
+
+Run tests and vet before collecting performance data:
+
+```sh
+go test ./...
+go vet ./...
+```
+
+## Storage benchmarks
+
+The storage suite compares the concurrency-safe in-memory implementation with
+SQLite. It measures atomic batches of 1, 10, and 100 events and a 50-row page
+read from 1,000 issues:
+
+```sh
+go test ./internal/store \
+  -run '^$' \
+  -bench 'Benchmark(RecordBatch|ListIssues)$' \
+  -benchmem \
+  -count 5
+```
+
+SQLite benchmarks create temporary databases and exclude database creation and
+fixture setup from the timed section. Batch inputs reuse a bounded set of
+fingerprints, so the write benchmark measures transaction, UPSERT, and readback
+cost rather than unbounded database growth.
+
+## HTTP handler benchmarks
+
+The application benchmark exercises the complete in-process HTTP handler,
+including JSON decoding, authentication, normalization, validation, storage,
+and JSON response encoding. It covers the single-event route and batches of 10
+and 100 events:
+
+```sh
+go test ./internal/server \
+  -run '^$' \
+  -bench BenchmarkIngestHandler \
+  -benchmem \
+  -count 5
+```
+
+Use `benchstat` or another statistical comparison tool when evaluating changes;
+do not compare single runs from different machines.
+
+## End-to-end pressure test
+
+Start an isolated Error-Tracer instance with a disposable SQLite database. The
+default rate limit is intentionally low for a pressure test, so raise it only in
+that isolated environment:
+
+```sh
+ERROR_TRACER_DATABASE_PATH=/tmp/error-tracer-loadtest.db \
+ERROR_TRACER_PROJECT_ID=loadtest \
+ERROR_TRACER_INGEST_KEY=replace-with-a-16-byte-key \
+ERROR_TRACER_ADMIN_TOKEN=replace-with-a-24-byte-token \
+ERROR_TRACER_RATE_PER_MINUTE=60000 \
+ERROR_TRACER_RATE_BURST=10000 \
+go run ./cmd/error-tracer
+```
+
+In another terminal, run a bounded test against the local batch endpoint:
+
+```sh
+ERROR_TRACER_INGEST_KEY=replace-with-a-16-byte-key \
+go run ./cmd/error-tracer-loadtest \
+  -target http://127.0.0.1:8080 \
+  -duration 30s \
+  -concurrency 16 \
+  -batch-size 50 \
+  -cardinality 1000 \
+  -rate 500
+```
+
+`-target` accepts the service base URL or the complete
+`/api/v1/events/batch` URL. The summary reports:
+
+- total requests and requests per second;
+- accepted requests, accepted events, and events per second;
+- HTTP status counts and transport-error count;
+- approximate p50, p95, p99, and maximum response latency.
+
+The default `-fail-on-error=true` makes the command exit non-zero if no request
+is accepted, a transport error occurs, or any response is not `202 Accepted`.
+Set `-fail-on-error=false` only when non-202 responses are part of the test.
+
+## Safety controls
+
+The load-test command is intentionally conservative:
+
+- A target is required; there is no implicit server address.
+- Non-loopback targets are refused unless `-allow-remote` is explicit.
+- Redirects are not followed and environment HTTP proxies are not used.
+- Duration is bounded to 1 second–30 minutes.
+- Concurrency is bounded to 1–1,000 workers.
+- Batch size is bounded to the server limit of 1–100 events.
+- Fingerprint cardinality is bounded to 1–100,000 distinct issues.
+- Optional request rate is bounded to 1,000,000 requests per second.
+- Per-request timeout is bounded to 100 milliseconds–1 minute.
+- The ingest key can come from `ERROR_TRACER_INGEST_KEY` and is never printed.
+
+Only use `-allow-remote` for infrastructure you own or are explicitly authorized
+to test. Coordinate the test window, retention plan, and alert suppression with
+the service owner before targeting a shared environment.
+
+## Interpreting results
+
+Increase one dimension at a time: request rate, concurrency, batch size, or
+fingerprint cardinality. Watch the service's CPU, memory, filesystem latency,
+database size, `429` responses, and tail latency. A useful capacity point keeps
+the accepted event rate stable without sustained error growth or unbounded p99
+latency.
+
+The application uses one SQLite connection to serialize writes. Large batches
+reduce transaction overhead, while high fingerprint cardinality increases
+database size and index work. Test both aggregation-heavy and high-cardinality
+profiles before choosing production limits.


### PR DESCRIPTION
## Summary

- correct the service table: the dashboard shell is public while live issue data requires the admin token
- add a complete Simplified Chinese README and cross-link both languages
- document the demo switch, public read-only routes, fixture isolation, and language URL behavior
- document storage/HTTP benchmarks, repeatable commands, metric interpretation, and the end-to-end load tester
- explain rate-limit configuration and remote-target safety before pressure testing
- add the demo flag and new public routes to the configuration/endpoint reference

## Dependencies

#33 and #34 are merged. This documentation also describes #35, so merge this PR after the localization PR.

## Verification

- checked relative documentation links
- `git diff --check`

CI intentionally skips Markdown-only changes.