### PR TITLE
fix: make HTTP shutdown bounded and deterministic

### DIFF
--- a/cmd/error-tracer/main.go
+++ b/cmd/error-tracer/main.go
@@ -17,24 +17,28 @@ import (
 )
 
 func main() {
+	os.Exit(run())
+}
+
+func run() int {
 	if len(os.Args) == 2 && os.Args[1] == "healthcheck" {
 		address := os.Getenv("ERROR_TRACER_ADDRESS")
 		if err := healthcheck.Check(context.Background(), address); err != nil {
 			slog.Error("health check failed", "error", err)
-			os.Exit(1)
+			return 1
 		}
-		return
+		return 0
 	}
 
 	cfg, err := config.FromEnvironment()
 	if err != nil {
 		slog.Error("invalid configuration", "error", err)
-		os.Exit(1)
+		return 1
 	}
 	issueStore, err := store.OpenSQLite(context.Background(), cfg.DatabasePath)
 	if err != nil {
 		slog.Error("open issue database", "error", err)
-		os.Exit(1)
+		return 1
 	}
 	defer func() {
 		if err := issueStore.Close(); err != nil {
@@ -65,14 +69,12 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	shutdownDone := make(chan struct{})
 	go func() {
+		defer close(shutdownDone)
 		<-ctx.Done()
 		app.SetReady(false)
-
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)
-		defer cancel()
-
-		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+		if err := stopHTTPServer(httpServer, cfg.ShutdownTimeout); err != nil {
 			slog.Error("graceful shutdown failed", "error", err)
 		}
 	}()
@@ -80,6 +82,26 @@ func main() {
 	slog.Info("starting Error-Tracer", "address", cfg.Address)
 	if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		slog.Error("server stopped unexpectedly", "error", err)
-		os.Exit(1)
+		return 1
 	}
+	<-shutdownDone
+	return 0
+}
+
+type httpShutdowner interface {
+	Shutdown(context.Context) error
+	Close() error
+}
+
+func stopHTTPServer(server httpShutdowner, timeout time.Duration) error {
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		if closeErr := server.Close(); closeErr != nil {
+			return errors.Join(err, closeErr)
+		}
+		return err
+	}
+	return nil
 }

--- a/cmd/error-tracer/main_test.go
+++ b/cmd/error-tracer/main_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type fakeHTTPServer struct {
+	shutdownErr error
+	closeErr    error
+	closed      bool
+}
+
+func (s *fakeHTTPServer) Shutdown(context.Context) error {
+	return s.shutdownErr
+}
+
+func (s *fakeHTTPServer) Close() error {
+	s.closed = true
+	return s.closeErr
+}
+
+func TestStopHTTPServerGraceful(t *testing.T) {
+	server := &fakeHTTPServer{}
+	if err := stopHTTPServer(server, time.Second); err != nil {
+		t.Fatalf("stopHTTPServer() error = %v", err)
+	}
+	if server.closed {
+		t.Fatal("Close() called after a successful graceful shutdown")
+	}
+}
+
+func TestStopHTTPServerForcesClose(t *testing.T) {
+	shutdownErr := errors.New("shutdown timed out")
+	server := &fakeHTTPServer{shutdownErr: shutdownErr}
+	if err := stopHTTPServer(server, time.Second); !errors.Is(err, shutdownErr) {
+		t.Fatalf("stopHTTPServer() error = %v, want %v", err, shutdownErr)
+	}
+	if !server.closed {
+		t.Fatal("Close() was not called after graceful shutdown failed")
+	}
+}
+
+func TestStopHTTPServerReportsCloseFailure(t *testing.T) {
+	shutdownErr := errors.New("shutdown timed out")
+	closeErr := errors.New("close failed")
+	server := &fakeHTTPServer{shutdownErr: shutdownErr, closeErr: closeErr}
+	err := stopHTTPServer(server, time.Second)
+	if !errors.Is(err, shutdownErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("stopHTTPServer() error = %v, want both shutdown and close errors", err)
+	}
+}


### PR DESCRIPTION
## Summary

- return exit codes from `run` so deferred SQLite cleanup executes before `os.Exit`
- wait for the shutdown worker before closing the database
- force-close active connections when graceful shutdown exceeds its deadline
- preserve both graceful and forced-close failures with `errors.Join`
- add focused shutdown regression tests

## Verification

- `go test ./cmd/error-tracer ./internal/...`
- `go test -race ./cmd/error-tracer ./internal/...`
- `git diff --check`