### PR TITLE
fix: make colliding tag normalization deterministic

### DIFF
--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 )
@@ -77,13 +78,27 @@ func (e *Event) Normalize() {
 		return
 	}
 
+	keys := make([]string, 0, len(e.Tags))
+	for key := range e.Tags {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
 	tags := make(map[string]string, len(e.Tags))
-	for key, value := range e.Tags {
-		key = strings.TrimSpace(key)
+	exactKeys := make(map[string]bool, len(e.Tags))
+	for _, originalKey := range keys {
+		key := strings.TrimSpace(originalKey)
 		if key == "" {
 			continue
 		}
-		tags[key] = strings.TrimSpace(value)
+		if originalKey == key {
+			tags[key] = strings.TrimSpace(e.Tags[originalKey])
+			exactKeys[key] = true
+			continue
+		}
+		if _, exists := tags[key]; !exists && !exactKeys[key] {
+			tags[key] = strings.TrimSpace(e.Tags[originalKey])
+		}
 	}
 	if len(tags) == 0 {
 		tags = nil

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -37,6 +37,44 @@ func TestNormalizeRemovesSensitiveURLComponents(t *testing.T) {
 	}
 }
 
+func TestNormalizeResolvesTagKeyCollisionsDeterministically(t *testing.T) {
+	tests := []struct {
+		name string
+		tags map[string]string
+		want string
+	}{
+		{
+			name: "exact key wins",
+			tags: map[string]string{
+				" role": "leading",
+				"role":  "exact",
+				"role ": "trailing",
+			},
+			want: "exact",
+		},
+		{
+			name: "first alias wins without exact key",
+			tags: map[string]string{
+				" role": "leading",
+				"role ": "trailing",
+			},
+			want: "leading",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for range 100 {
+				captured := Event{Tags: test.tags}
+				captured.Normalize()
+				if len(captured.Tags) != 1 || captured.Tags["role"] != test.want {
+					t.Fatalf("Tags = %#v, want role=%q", captured.Tags, test.want)
+				}
+			}
+		})
+	}
+}
+
 func TestValidateAcceptsSupportedEvents(t *testing.T) {
 	tests := []Event{
 		{Kind: KindError, Message: "boom"},


### PR DESCRIPTION
## Summary

- sort incoming tag keys before normalization
- prefer an already-normalized exact key over whitespace aliases
- choose a stable alias when no exact key exists
- cover both collision cases repeatedly to catch map-order regressions

Without this change, keys such as `role`, ` role`, and `role ` collapse to the same normalized key and Go's randomized map iteration decides which value is persisted.

## Verification

- `go test ./...`
- `go test -race ./...`
- `npm test`
- `git diff --check`