### PR TITLE
feat: make the read-only demo directly accessible

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,4 +14,5 @@ ERROR_TRACER_RATE_PER_MINUTE=120
 ERROR_TRACER_RATE_BURST=30
 
 # Enables a public, read-only dashboard backed only by built-in sample data.
+# When enabled, open /?demo=1 to enter the demo without credentials.
 ERROR_TRACER_DEMO_MODE=false

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -21,6 +21,18 @@ sample occurrences in total. Filtering, pagination, issue details, localized
 dates, and the English/Simplified Chinese UI can be evaluated without an admin
 token.
 
+For a link that opens the sample dashboard immediately, add `demo=1`:
+
+```text
+http://localhost:8080/?demo=1
+http://localhost:8080/?demo=1&lang=zh-CN
+```
+
+The direct link works only while `ERROR_TRACER_DEMO_MODE=true`. Opening the demo
+from the sign-in panel adds the same query parameter, so the current view can be
+copied or bookmarked. Disconnecting removes it and returns to the private
+sign-in panel.
+
 ## Security boundary
 
 The demo is deliberately separate from production data:

--- a/internal/server/dashboard/dashboard.js
+++ b/internal/server/dashboard/dashboard.js
@@ -243,6 +243,7 @@
       showMessage(elements.loginMessage, message("login.tokenTooShort"), true);
       return;
     }
+    updateDemoURL(false);
     state.demo = false;
     state.token = token;
     state.offset = 0;
@@ -261,10 +262,21 @@
     }
   });
 
-  elements.demo.addEventListener("click", async () => {
+  elements.demo.addEventListener("click", () => {
+    enterDemo(true);
+  });
+
+  async function enterDemo(updateURL) {
     state.token = "";
     state.demo = true;
+    state.status = "";
     state.offset = 0;
+    state.page = null;
+    state.selected = null;
+    elements.statusFilter.value = "";
+    if (updateURL) {
+      updateDemoURL(true);
+    }
     setLoginBusy(true);
     showMessage(elements.loginMessage, message("login.loadingDemo"), false);
     try {
@@ -276,7 +288,7 @@
     } finally {
       setLoginBusy(false);
     }
-  });
+  }
 
   elements.refresh.addEventListener("click", () => {
     loadIssues().catch(showWorkspaceError);
@@ -566,6 +578,7 @@
     elements.connection.hidden = true;
     elements.demoBanner.hidden = true;
     elements.statusFilter.value = "";
+    updateDemoURL(false);
     updateConnectionLabel();
     elements.loginPanel.hidden = false;
     elements.tokenInput.value = "";
@@ -800,9 +813,34 @@
         return;
       }
       const metadata = await response.json();
-      elements.demo.hidden = metadata.demo_mode !== true;
+      const available = metadata.demo_mode === true;
+      elements.demo.hidden = !available;
+      if (available && demoRequested()) {
+        await enterDemo(false);
+      } else if (!available && demoRequested()) {
+        showMessage(elements.loginMessage, message("errors.demoUnavailable"), true);
+      }
     } catch (_) {
       elements.demo.hidden = true;
+    }
+  }
+
+  function demoRequested() {
+    const requested = new URLSearchParams(window.location.search).get("demo");
+    return requested === "1" || String(requested).toLowerCase() === "true";
+  }
+
+  function updateDemoURL(enabled) {
+    try {
+      const currentURL = new URL(window.location.href);
+      if (enabled) {
+        currentURL.searchParams.set("demo", "1");
+      } else {
+        currentURL.searchParams.delete("demo");
+      }
+      window.history.replaceState(null, "", currentURL);
+    } catch (_) {
+      // Demo selection still works when URL history is unavailable.
     }
   }
 

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -121,7 +121,13 @@ func TestDashboardScriptAvoidsCredentialPersistenceAndHTMLInjection(t *testing.T
 	if !strings.Contains(dashboardScript.body, "textContent") {
 		t.Fatal("dashboard script does not use textContent for rendering")
 	}
-	for _, marker := range []string{"/api/v1/meta", "/api/v1/demo/issues"} {
+	for _, marker := range []string{
+		"/api/v1/meta",
+		"/api/v1/demo/issues",
+		`new URLSearchParams(window.location.search).get("demo")`,
+		`searchParams.set("demo", "1")`,
+		`searchParams.delete("demo")`,
+	} {
 		if !strings.Contains(dashboardScript.body, marker) {
 			t.Fatalf("dashboard script does not contain demo marker %q", marker)
 		}


### PR DESCRIPTION
## Summary

- support `/?demo=1` and `/?demo=true` as direct, credential-free demo links
- automatically open the isolated read-only workspace only when demo mode is enabled
- make the existing demo button add a bookmarkable URL parameter
- remove the demo parameter when disconnecting or connecting to the live admin view
- document English and Chinese direct-demo links

The live SQLite store and authenticated management API remain isolated from the demo store.

## Verification

- `go test ./...`
- `go test -race ./...`
- `npm test`
- `git diff --check`