### PR TITLE
feat: add stable cursor pagination for issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ Authorization: Bearer replace-with-the-admin-token
 
 | Method | Path | Purpose |
 | --- | --- | --- |
-| `GET` | `/api/v1/issues?limit=50&offset=0` | List issues, newest first |
+| `GET` | `/api/v1/issues?limit=50` | List the first page, newest first |
+| `GET` | `/api/v1/issues?limit=50&cursor=...` | Continue from `next_cursor` |
 | `GET` | `/api/v1/issues?status=open` | Filter by `open`, `resolved`, or `ignored` |
 | `GET` | `/api/v1/issues/{fingerprint}` | Read one issue |
 | `PATCH` | `/api/v1/issues/{fingerprint}` | Change the issue status |
@@ -194,7 +195,11 @@ Status update body:
 }
 ```
 
-Pages are limited to 100 issues. Offsets above 100,000 are rejected.
+Pages are limited to 100 issues. When another page exists, the response includes
+an opaque `next_cursor`; pass it back with the same `limit` and `status` filter.
+Cursor and offset cannot be combined. The legacy `offset` parameter remains
+available for compatibility, but offsets above 100,000 are rejected. The
+embedded dashboard uses cursor pagination.
 
 ## Service endpoints
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -148,7 +148,8 @@ Authorization: Bearer 替换为管理员令牌
 
 | 方法 | 路径 | 用途 |
 | --- | --- | --- |
-| `GET` | `/api/v1/issues?limit=50&offset=0` | 按最新出现时间列出问题 |
+| `GET` | `/api/v1/issues?limit=50` | 按最新出现时间读取第一页 |
+| `GET` | `/api/v1/issues?limit=50&cursor=...` | 使用 `next_cursor` 继续读取 |
 | `GET` | `/api/v1/issues?status=open` | 按 `open`、`resolved` 或 `ignored` 筛选 |
 | `GET` | `/api/v1/issues/{fingerprint}` | 读取单个问题 |
 | `PATCH` | `/api/v1/issues/{fingerprint}` | 修改问题状态 |
@@ -161,7 +162,10 @@ Authorization: Bearer 替换为管理员令牌
 }
 ```
 
-每页最多返回 100 个问题，超过 100,000 的偏移量会被拒绝。
+每页最多返回 100 个问题。存在下一页时，响应会包含不透明的 `next_cursor`；
+继续请求时应保持相同的 `limit` 和 `status` 筛选。游标不能与偏移量同时使用。
+为兼容旧客户端，`offset` 参数仍然保留，但超过 100,000 的偏移量会被拒绝；
+内嵌 Dashboard 已改用游标分页。
 
 ## 服务端点
 

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -57,9 +57,10 @@ that do not need a public product tour.
 | `GET` | `/api/v1/demo/issues?status=open` | Built-in issues filtered by status |
 | `GET` | `/api/v1/demo/issues/{fingerprint}` | One built-in issue and its latest event |
 
-The list endpoint accepts the same bounded `limit`, `offset`, and `status`
-parameters as the authenticated issue API. Attempts to `PATCH` a demo issue
-return `405 Method Not Allowed`.
+The list endpoint accepts the same bounded `limit`, `cursor`, legacy `offset`,
+and `status` parameters as the authenticated issue API. A page with more data
+returns `next_cursor`. Attempts to `PATCH` a demo issue return
+`405 Method Not Allowed`.
 
 ## Language selection
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -39,8 +39,8 @@ scrape_configs:
 ## Storage benchmarks
 
 The storage suite compares the concurrency-safe in-memory implementation with
-SQLite. It measures atomic batches of 1, 10, and 100 events and a 50-row page
-read from 1,000 issues:
+SQLite. It measures atomic batches of 1, 10, and 100 events and 50-row offset
+and cursor page reads from 1,000 issues:
 
 ```sh
 go test ./internal/store \

--- a/internal/server/dashboard/dashboard.js
+++ b/internal/server/dashboard/dashboard.js
@@ -221,7 +221,9 @@
     demo: false,
     status: "",
     limit: 25,
-    offset: 0,
+    cursor: "",
+    cursorHistory: [],
+    pageIndex: 0,
     page: null,
     selected: null,
     loading: false,
@@ -246,7 +248,7 @@
     updateDemoURL(false);
     state.demo = false;
     state.token = token;
-    state.offset = 0;
+    resetPagination();
     setLoginBusy(true);
     showMessage(elements.loginMessage, message("login.connecting"), false);
     try {
@@ -270,7 +272,7 @@
     state.token = "";
     state.demo = true;
     state.status = "";
-    state.offset = 0;
+    resetPagination();
     state.page = null;
     state.selected = null;
     elements.statusFilter.value = "";
@@ -300,18 +302,23 @@
 
   elements.statusFilter.addEventListener("change", () => {
     state.status = elements.statusFilter.value;
-    state.offset = 0;
+    resetPagination();
     loadIssues().catch(showWorkspaceError);
   });
 
   elements.previous.addEventListener("click", () => {
-    state.offset = Math.max(0, state.offset - state.limit);
-    loadIssues().catch(showWorkspaceError);
+    if (state.cursorHistory.length > 0) {
+      state.cursor = state.cursorHistory.pop();
+      state.pageIndex = Math.max(0, state.pageIndex - 1);
+      loadIssues().catch(showWorkspaceError);
+    }
   });
 
   elements.next.addEventListener("click", () => {
-    if (state.page && state.offset + state.limit < state.page.total) {
-      state.offset += state.limit;
+    if (state.page && state.page.next_cursor) {
+      state.cursorHistory.push(state.cursor);
+      state.cursor = state.page.next_cursor;
+      state.pageIndex++;
       loadIssues().catch(showWorkspaceError);
     }
   });
@@ -344,20 +351,21 @@
     setWorkspaceBusy(true);
     showMessage(elements.workspaceMessage, () => "", false);
     try {
-      const query = new URLSearchParams({
-        limit: String(state.limit),
-        offset: String(state.offset),
-      });
+      const query = new URLSearchParams({ limit: String(state.limit) });
+      if (state.cursor) {
+        query.set("cursor", state.cursor);
+      }
       if (state.status) {
         query.set("status", state.status);
       }
       state.page = await requestJSON(`/api/v1/issues?${query}`);
-      if (state.offset > 0 && state.page.total <= state.offset) {
-        state.offset = Math.max(
-          0,
-          Math.floor(Math.max(0, state.page.total - 1) / state.limit) * state.limit,
-        );
-        query.set("offset", String(state.offset));
+      if (state.cursor && state.page.issues.length === 0 && state.cursorHistory.length > 0) {
+        state.cursor = state.cursorHistory.pop();
+        state.pageIndex = Math.max(0, state.pageIndex - 1);
+        query.set("cursor", state.cursor);
+        if (!state.cursor) {
+          query.delete("cursor");
+        }
         state.page = await requestJSON(`/api/v1/issues?${query}`);
       }
       renderPage(state.page);
@@ -449,8 +457,9 @@
       ? relativeTime(issues[0].last_seen)
       : t("metrics.quiet");
 
-    const start = page.total ? state.offset + 1 : 0;
-    const end = Math.min(state.offset + issues.length, page.total || 0);
+    const pageOffset = state.pageIndex * state.limit;
+    const start = page.total ? pageOffset + 1 : 0;
+    const end = Math.min(pageOffset + issues.length, page.total || 0);
     elements.resultCopy.textContent = page.total
       ? t("issues.showing", {
         start: integerFormat.format(start),
@@ -459,10 +468,10 @@
       })
       : t("issues.noResults");
     elements.pageCopy.textContent = t("issues.page", {
-      page: integerFormat.format(Math.floor(state.offset / state.limit) + 1),
+      page: integerFormat.format(state.pageIndex + 1),
     });
-    elements.previous.disabled = state.offset === 0;
-    elements.next.disabled = state.offset + state.limit >= (page.total || 0);
+    elements.previous.disabled = state.cursorHistory.length === 0;
+    elements.next.disabled = !page.next_cursor;
   }
 
   function issueRow(issue) {
@@ -570,7 +579,7 @@
     state.token = "";
     state.demo = false;
     state.status = "";
-    state.offset = 0;
+    resetPagination();
     state.page = null;
     state.selected = null;
     closeIssueDialog();
@@ -629,9 +638,14 @@
   function setWorkspaceBusy(busy) {
     elements.refresh.disabled = busy;
     elements.statusFilter.disabled = busy;
-    elements.previous.disabled = busy || state.offset === 0;
-    elements.next.disabled = busy || !state.page ||
-      state.offset + state.limit >= state.page.total;
+    elements.previous.disabled = busy || state.cursorHistory.length === 0;
+    elements.next.disabled = busy || !state.page || !state.page.next_cursor;
+  }
+
+  function resetPagination() {
+    state.cursor = "";
+    state.cursorHistory = [];
+    state.pageIndex = 0;
   }
 
   function setStatusButtonsBusy(busy) {

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -137,10 +137,15 @@ func TestDashboardScriptAvoidsCredentialPersistenceAndHTMLInjection(t *testing.T
 		"Intl.RelativeTimeFormat",
 		"history.replaceState",
 		"data-i18n",
+		"next_cursor",
+		"cursorHistory",
 	} {
 		if !strings.Contains(dashboardScript.body, marker) {
 			t.Fatalf("dashboard script does not contain localization marker %q", marker)
 		}
+	}
+	if strings.Contains(dashboardScript.body, "offset: String(state.offset)") {
+		t.Fatal("dashboard still uses offset pagination")
 	}
 }
 

--- a/internal/server/demo.go
+++ b/internal/server/demo.go
@@ -49,7 +49,7 @@ func (s *Server) listDemoIssues(w http.ResponseWriter, request *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "internal_error"})
 		return
 	}
-	writeJSON(w, http.StatusOK, page)
+	writeIssuePage(w, page)
 }
 
 func (s *Server) getDemoIssue(w http.ResponseWriter, request *http.Request) {

--- a/internal/server/issues.go
+++ b/internal/server/issues.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -8,6 +10,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/soulteary/Error-Tracer/internal/store"
 )
@@ -15,10 +18,17 @@ import (
 const (
 	maxIssueOffset         = 100_000
 	maxIssueUpdateBodySize = 4 * 1024
+	issueCursorVersion     = 1
+	issueCursorSize        = 1 + 8 + 32
 )
 
 type issueResponse struct {
 	Issue store.Issue `json:"issue"`
+}
+
+type issuePageResponse struct {
+	store.IssuePage
+	NextCursor string `json:"next_cursor,omitempty"`
 }
 
 type issueUpdateRequest struct {
@@ -44,7 +54,7 @@ func (s *Server) listIssues(w http.ResponseWriter, request *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "internal_error"})
 		return
 	}
-	writeJSON(w, http.StatusOK, page)
+	writeIssuePage(w, page)
 }
 
 func (s *Server) getIssue(w http.ResponseWriter, request *http.Request) {
@@ -133,7 +143,7 @@ func (s *Server) authorizeAdmin(w http.ResponseWriter, request *http.Request) bo
 
 func parseListOptions(request *http.Request) (store.ListOptions, error) {
 	query := request.URL.Query()
-	if len(query["limit"]) > 1 || len(query["offset"]) > 1 {
+	if len(query["limit"]) > 1 || len(query["offset"]) > 1 || len(query["cursor"]) > 1 {
 		return store.ListOptions{}, errors.New("pagination parameters must not be repeated")
 	}
 	if len(query["status"]) > 1 {
@@ -141,6 +151,9 @@ func parseListOptions(request *http.Request) (store.ListOptions, error) {
 	}
 
 	var options store.ListOptions
+	if _, hasOffset := query["offset"]; hasOffset && query.Get("cursor") != "" {
+		return store.ListOptions{}, errors.New("offset and cursor are mutually exclusive")
+	}
 	if raw := query.Get("limit"); raw != "" {
 		limit, err := strconv.Atoi(raw)
 		if err != nil || limit < 1 || limit > 100 {
@@ -155,6 +168,13 @@ func parseListOptions(request *http.Request) (store.ListOptions, error) {
 		}
 		options.Offset = offset
 	}
+	if raw := query.Get("cursor"); raw != "" {
+		cursor, err := decodeIssueCursor(raw)
+		if err != nil {
+			return store.ListOptions{}, err
+		}
+		options.After = &cursor
+	}
 	if raw := query.Get("status"); raw != "" {
 		options.Status = store.IssueStatus(raw)
 		if !options.Status.Valid() {
@@ -162,6 +182,39 @@ func parseListOptions(request *http.Request) (store.ListOptions, error) {
 		}
 	}
 	return options, nil
+}
+
+func writeIssuePage(w http.ResponseWriter, page store.IssuePage) {
+	writeJSON(w, http.StatusOK, issuePageResponse{
+		IssuePage:  page,
+		NextCursor: encodeIssueCursor(page.Next),
+	})
+}
+
+func encodeIssueCursor(cursor *store.ListCursor) string {
+	if cursor == nil {
+		return ""
+	}
+	fingerprint, err := hex.DecodeString(cursor.Fingerprint)
+	if err != nil || len(fingerprint) != 32 {
+		return ""
+	}
+	encoded := make([]byte, issueCursorSize)
+	encoded[0] = issueCursorVersion
+	binary.BigEndian.PutUint64(encoded[1:9], uint64(cursor.LastSeen.UnixNano()))
+	copy(encoded[9:], fingerprint)
+	return base64.RawURLEncoding.EncodeToString(encoded)
+}
+
+func decodeIssueCursor(value string) (store.ListCursor, error) {
+	decoded, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil || len(decoded) != issueCursorSize || decoded[0] != issueCursorVersion {
+		return store.ListCursor{}, errors.New("invalid cursor")
+	}
+	return store.ListCursor{
+		LastSeen:    time.Unix(0, int64(binary.BigEndian.Uint64(decoded[1:9]))).UTC(),
+		Fingerprint: hex.EncodeToString(decoded[9:]),
+	}, nil
 }
 
 func validFingerprint(value string) bool {

--- a/internal/server/issues_test.go
+++ b/internal/server/issues_test.go
@@ -81,6 +81,53 @@ func TestListIssuesReturnsBoundedPage(t *testing.T) {
 	}
 }
 
+func TestListIssuesContinuesWithOpaqueCursor(t *testing.T) {
+	memory := store.NewMemory()
+	base := time.Date(2026, time.August, 29, 2, 0, 0, 0, time.UTC)
+	for index, message := range []string{"first", "second", "third"} {
+		captured := event.Event{
+			Kind:       event.KindError,
+			Message:    message,
+			ReceivedAt: base.Add(time.Duration(index) * time.Minute),
+		}
+		if _, err := memory.Record(context.Background(), "project-a", captured); err != nil {
+			t.Fatalf("record issue: %v", err)
+		}
+	}
+	app := New(Options{
+		Store: memory, ProjectID: "project-a", IngestKey: "0123456789abcdef", AdminToken: testAdminToken,
+	})
+
+	firstResponse := httptest.NewRecorder()
+	app.Handler().ServeHTTP(
+		firstResponse,
+		authorizedRequest(http.MethodGet, "/api/v1/issues?limit=2"),
+	)
+	var first issuePageResponse
+	if err := json.NewDecoder(firstResponse.Body).Decode(&first); err != nil {
+		t.Fatalf("decode first page: %v", err)
+	}
+	if len(first.Issues) != 2 || first.NextCursor == "" {
+		t.Fatalf("first page = %#v, want two issues and next_cursor", first)
+	}
+
+	secondResponse := httptest.NewRecorder()
+	app.Handler().ServeHTTP(
+		secondResponse,
+		authorizedRequest(
+			http.MethodGet,
+			"/api/v1/issues?limit=2&cursor="+first.NextCursor,
+		),
+	)
+	var second issuePageResponse
+	if err := json.NewDecoder(secondResponse.Body).Decode(&second); err != nil {
+		t.Fatalf("decode second page: %v", err)
+	}
+	if len(second.Issues) != 1 || second.Issues[0].Message != "first" || second.NextCursor != "" {
+		t.Fatalf("second page = %#v, want final issue", second)
+	}
+}
+
 func TestListIssuesRejectsInvalidPagination(t *testing.T) {
 	for _, target := range []string{
 		"/api/v1/issues?limit=0",
@@ -89,6 +136,11 @@ func TestListIssuesRejectsInvalidPagination(t *testing.T) {
 		"/api/v1/issues?limit=1&limit=2",
 		"/api/v1/issues?offset=-1",
 		"/api/v1/issues?offset=100001",
+		"/api/v1/issues?cursor=invalid",
+		"/api/v1/issues?cursor=one&cursor=two",
+		"/api/v1/issues?offset=0&cursor=" + encodeIssueCursor(&store.ListCursor{
+			LastSeen: time.Now().UTC(), Fingerprint: strings.Repeat("0", 64),
+		}),
 	} {
 		t.Run(target, func(t *testing.T) {
 			response := httptest.NewRecorder()
@@ -97,6 +149,24 @@ func TestListIssuesRejectsInvalidPagination(t *testing.T) {
 				t.Fatalf("status = %d, want %d", response.Code, http.StatusBadRequest)
 			}
 		})
+	}
+}
+
+func TestIssueCursorRoundTrip(t *testing.T) {
+	want := store.ListCursor{
+		LastSeen:    time.Date(2026, time.August, 29, 2, 3, 4, 567, time.UTC),
+		Fingerprint: strings.Repeat("a", 64),
+	}
+	encoded := encodeIssueCursor(&want)
+	if encoded == "" || strings.ContainsAny(encoded, "+/=") {
+		t.Fatalf("encoded cursor = %q, want raw URL-safe base64", encoded)
+	}
+	got, err := decodeIssueCursor(encoded)
+	if err != nil {
+		t.Fatalf("decodeIssueCursor() error = %v", err)
+	}
+	if !got.LastSeen.Equal(want.LastSeen) || got.Fingerprint != want.Fingerprint {
+		t.Fatalf("decoded cursor = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/store/benchmark_test.go
+++ b/internal/store/benchmark_test.go
@@ -95,17 +95,35 @@ func BenchmarkListIssues(b *testing.B) {
 					b.Fatalf("seed issues: %v", err)
 				}
 			}
-			options := ListOptions{Limit: 50, Offset: 475}
-			b.ReportAllocs()
-			b.ResetTimer()
-			for range b.N {
-				page, err := issueStore.ListIssues(context.Background(), "benchmark", options)
-				if err != nil {
-					b.Fatalf("list issues: %v", err)
-				}
-				if len(page.Issues) != 50 || page.Total != 1_000 {
-					b.Fatalf("unexpected page: %d of %d", len(page.Issues), page.Total)
-				}
+			anchor, err := issueStore.ListIssues(
+				context.Background(), "benchmark", ListOptions{Limit: 50, Offset: 425},
+			)
+			if err != nil || anchor.Next == nil {
+				b.Fatalf("build cursor anchor: page=%#v error=%v", anchor, err)
+			}
+			cases := []struct {
+				name    string
+				options ListOptions
+			}{
+				{name: "Offset_475", options: ListOptions{Limit: 50, Offset: 475}},
+				{name: "Cursor_475", options: ListOptions{Limit: 50, After: anchor.Next}},
+			}
+			for _, test := range cases {
+				b.Run(test.name, func(b *testing.B) {
+					b.ReportAllocs()
+					b.ResetTimer()
+					for range b.N {
+						page, err := issueStore.ListIssues(
+							context.Background(), "benchmark", test.options,
+						)
+						if err != nil {
+							b.Fatalf("list issues: %v", err)
+						}
+						if len(page.Issues) != 50 || page.Total != 1_000 {
+							b.Fatalf("unexpected page: %d of %d", len(page.Issues), page.Total)
+						}
+					}
+				})
 			}
 		})
 	}

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -134,13 +134,29 @@ func (m *Memory) ListIssues(ctx context.Context, projectID string, options ListO
 
 	total := len(issues)
 	start := min(options.Offset, total)
+	if options.After != nil {
+		start = sort.Search(total, func(index int) bool {
+			return issueIsAfterCursor(issues[index], *options.After)
+		})
+	}
 	end := min(start+options.Limit, total)
+	var next *ListCursor
+	if end < total && end > start {
+		last := issues[end-1]
+		next = &ListCursor{LastSeen: last.LastSeen, Fingerprint: last.Fingerprint}
+	}
 	return IssuePage{
 		Issues: issues[start:end],
 		Total:  total,
 		Limit:  options.Limit,
 		Offset: options.Offset,
+		Next:   next,
 	}, nil
+}
+
+func issueIsAfterCursor(issue Issue, cursor ListCursor) bool {
+	return issue.LastSeen.Before(cursor.LastSeen) ||
+		(issue.LastSeen.Equal(cursor.LastSeen) && issue.Fingerprint > cursor.Fingerprint)
 }
 
 // SetIssueStatus updates the triage state of one issue.

--- a/internal/store/memory_test.go
+++ b/internal/store/memory_test.go
@@ -127,6 +127,38 @@ func TestMemoryListIssuesIsBoundedAndOrdered(t *testing.T) {
 	}
 }
 
+func TestMemoryListIssuesContinuesFromCursor(t *testing.T) {
+	memory := NewMemory()
+	base := time.Date(2026, time.August, 29, 1, 0, 0, 0, time.UTC)
+	for index := 0; index < 3; index++ {
+		captured := testEvent(base.Add(time.Duration(index) * time.Minute))
+		captured.Message = fmt.Sprintf("cursor-%d", index)
+		if _, err := memory.Record(context.Background(), "project-a", captured); err != nil {
+			t.Fatalf("record event %d: %v", index, err)
+		}
+	}
+
+	first, err := memory.ListIssues(context.Background(), "project-a", ListOptions{Limit: 2})
+	if err != nil {
+		t.Fatalf("list first page: %v", err)
+	}
+	if len(first.Issues) != 2 || first.Next == nil {
+		t.Fatalf("first page = %#v, want two issues and a cursor", first)
+	}
+	second, err := memory.ListIssues(
+		context.Background(), "project-a", ListOptions{Limit: 2, After: first.Next},
+	)
+	if err != nil {
+		t.Fatalf("list second page: %v", err)
+	}
+	if second.Total != 3 || len(second.Issues) != 1 || second.Next != nil {
+		t.Fatalf("second page = %#v, want final issue without cursor", second)
+	}
+	if second.Issues[0].Message != "cursor-0" {
+		t.Fatalf("second page message = %q, want cursor-0", second.Issues[0].Message)
+	}
+}
+
 func TestMemoryListIssuesFiltersByStatus(t *testing.T) {
 	memory := NewMemory()
 	base := time.Date(2026, time.August, 29, 1, 0, 0, 0, time.UTC)

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -35,6 +35,12 @@ CREATE INDEX IF NOT EXISTS issues_project_status_last_seen
 
 CREATE INDEX IF NOT EXISTS issues_project_last_seen
     ON issues (project_id, last_seen);
+
+CREATE INDEX IF NOT EXISTS issues_project_last_seen_fingerprint
+    ON issues (project_id, last_seen DESC, fingerprint ASC);
+
+CREATE INDEX IF NOT EXISTS issues_project_status_last_seen_fingerprint
+    ON issues (project_id, status, last_seen DESC, fingerprint ASC);
 `
 
 const sqliteUpsertIssue = `
@@ -226,15 +232,25 @@ func (s *SQLite) ListIssues(ctx context.Context, projectID string, options ListO
 		whereClause += " AND status = ?"
 		queryArguments = append(queryArguments, options.Status)
 	}
+	countArguments := append([]any{}, queryArguments...)
 
 	var total int
 	if err := transaction.QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM issues WHERE "+whereClause, queryArguments...,
+		"SELECT COUNT(*) FROM issues WHERE "+whereClause, countArguments...,
 	).Scan(&total); err != nil {
 		return IssuePage{}, fmt.Errorf("count issues: %w", err)
 	}
+	if options.After != nil {
+		whereClause += " AND (last_seen < ? OR (last_seen = ? AND fingerprint > ?))"
+		lastSeen := options.After.LastSeen.UnixNano()
+		queryArguments = append(
+			queryArguments, lastSeen, lastSeen, options.After.Fingerprint,
+		)
+	}
 
-	listArguments := append(append([]any{}, queryArguments...), options.Limit, options.Offset)
+	listArguments := append(
+		append([]any{}, queryArguments...), options.Limit+1, options.Offset,
+	)
 	rows, err := transaction.QueryContext(ctx, `
 SELECT project_id, fingerprint, kind, message, source_url, line, column_number,
        status, occurrences, first_seen, last_seen, last_event
@@ -248,7 +264,7 @@ LIMIT ? OFFSET ?
 	}
 	defer rows.Close()
 
-	issues := make([]Issue, 0, min(options.Limit, total))
+	issues := make([]Issue, 0, min(options.Limit+1, total))
 	for rows.Next() {
 		issue, err := scanIssue(rows)
 		if err != nil {
@@ -265,12 +281,19 @@ LIMIT ? OFFSET ?
 	if err := transaction.Commit(); err != nil {
 		return IssuePage{}, fmt.Errorf("commit list transaction: %w", err)
 	}
+	var next *ListCursor
+	if len(issues) > options.Limit {
+		issues = issues[:options.Limit]
+		last := issues[len(issues)-1]
+		next = &ListCursor{LastSeen: last.LastSeen, Fingerprint: last.Fingerprint}
+	}
 
 	return IssuePage{
 		Issues: issues,
 		Total:  total,
 		Limit:  options.Limit,
 		Offset: options.Offset,
+		Next:   next,
 	}, nil
 }
 

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -149,6 +150,44 @@ func TestSQLiteListIssuesIsProjectScopedBoundedAndOrdered(t *testing.T) {
 	}
 	if page.Issues[0].ProjectID != "project-a" {
 		t.Fatalf("project ID = %q, want project-a", page.Issues[0].ProjectID)
+	}
+}
+
+func TestSQLiteListIssuesCursorHandlesEqualTimestamps(t *testing.T) {
+	database := openTestSQLite(t, ":memory:")
+	t.Cleanup(func() { _ = database.Close() })
+	receivedAt := time.Date(2026, time.August, 29, 1, 0, 0, 0, time.UTC)
+	for _, message := range []string{"cursor-a", "cursor-b", "cursor-c"} {
+		captured := testEvent(receivedAt)
+		captured.Message = message
+		if _, err := database.Record(context.Background(), "project-a", captured); err != nil {
+			t.Fatalf("record %q: %v", message, err)
+		}
+	}
+
+	first, err := database.ListIssues(context.Background(), "project-a", ListOptions{Limit: 2})
+	if err != nil {
+		t.Fatalf("list first page: %v", err)
+	}
+	if len(first.Issues) != 2 || first.Next == nil {
+		t.Fatalf("first page = %#v, want two issues and a cursor", first)
+	}
+	second, err := database.ListIssues(
+		context.Background(), "project-a", ListOptions{Limit: 2, After: first.Next},
+	)
+	if err != nil {
+		t.Fatalf("list second page: %v", err)
+	}
+	if len(second.Issues) != 1 || second.Next != nil {
+		t.Fatalf("second page = %#v, want final issue without cursor", second)
+	}
+	fingerprints := []string{
+		first.Issues[0].Fingerprint,
+		first.Issues[1].Fingerprint,
+		second.Issues[0].Fingerprint,
+	}
+	if !sort.StringsAreSorted(fingerprints) {
+		t.Fatalf("fingerprints = %#v, want stable ascending tie-break order", fingerprints)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -64,14 +64,22 @@ type ListOptions struct {
 	Limit  int
 	Offset int
 	Status IssueStatus
+	After  *ListCursor
+}
+
+// ListCursor identifies the last issue returned by a stable ordered page.
+type ListCursor struct {
+	LastSeen    time.Time
+	Fingerprint string
 }
 
 // IssuePage is a stable page of issues and the total matching count.
 type IssuePage struct {
-	Issues []Issue `json:"issues"`
-	Total  int     `json:"total"`
-	Limit  int     `json:"limit"`
-	Offset int     `json:"offset"`
+	Issues []Issue     `json:"issues"`
+	Total  int         `json:"total"`
+	Limit  int         `json:"limit"`
+	Offset int         `json:"offset"`
+	Next   *ListCursor `json:"-"`
 }
 
 // Store records events and exposes their aggregated issues.
@@ -91,6 +99,9 @@ func normalizeListOptions(options ListOptions) ListOptions {
 		options.Limit = maxPageSize
 	}
 	if options.Offset < 0 {
+		options.Offset = 0
+	}
+	if options.After != nil {
 		options.Offset = 0
 	}
 	return options


### PR DESCRIPTION
## Summary

- add versioned URL-safe opaque cursors based on the stable `last_seen DESC, fingerprint ASC` order
- return `next_cursor` from both authenticated and isolated demo list APIs
- keep legacy offset pagination for compatibility and reject offset/cursor combinations
- switch the embedded dashboard to cursor history for next/previous navigation
- add SQLite covering indexes for filtered and unfiltered cursor scans
- cover equal-timestamp tie breaking, cursor encoding, invalid cursors, and multi-page API traversal
- benchmark offset and cursor reads side by side

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `npm test`
- `go test ./internal/store -run '^$' -bench BenchmarkListIssues -benchtime=1x -count=1`
- `git diff --check`