### PR TITLE
feat: add a configuration-free demo command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,31 @@ tag. It is not part of the current runtime.
 - Offers English and Simplified Chinese dashboard locales without browser
   storage.
 - Includes an opt-in, read-only demo backed only by built-in in-memory data.
+- Starts a configuration-free, database-free product tour with `error-tracer demo`.
 - Enforces request-size limits, exact browser-origin allowlists, per-peer rate
   limits, and constant-time credential comparisons.
 - Runs as a single static binary or a non-root, read-only container.
 - Ships database/application benchmarks and a bounded HTTP load-test command.
+
+## Try the demo without configuration
+
+Run the product tour directly from the source tree:
+
+```sh
+go run ./cmd/error-tracer demo
+```
+
+Then open <http://127.0.0.1:8080/>. The dashboard enters the built-in read-only
+sample workspace immediately. This command does not require credentials, does
+not open SQLite, and does not register the event ingestion or admin issue
+routes.
+
+The same isolated tour can run from the container image:
+
+```sh
+docker build -t error-tracer:demo .
+docker run --rm --read-only -p 127.0.0.1:8080:8080 error-tracer:demo demo
+```
 
 ## Quick start with Docker Compose
 
@@ -207,7 +228,7 @@ embedded dashboard uses cursor pagination.
 | --- | --- | --- | --- |
 | `GET` | `/` | None | Dashboard shell; live data calls require an admin token |
 | `GET` | `/assets/error-tracer.js` | None | Embedded browser SDK |
-| `GET` | `/api/v1/meta` | None | Public feature metadata; currently only the demo flag |
+| `GET` | `/api/v1/meta` | None | Public demo availability and demo-only mode flags |
 | `GET` | `/api/v1/demo/issues` | None, demo mode only | List built-in read-only demo issues |
 | `GET` | `/api/v1/demo/issues/{fingerprint}` | None, demo mode only | Read one built-in demo issue |
 | `POST` | `/api/v1/events` | Ingest key in the body | Submit one event |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -21,9 +21,29 @@ Error-Tracer 是一个轻量、自托管的浏览器错误收集器。当前服�
 - 提供带鉴权的 JSON API 和内嵌 Dashboard。
 - Dashboard 支持 English / 简体中文，且不依赖浏览器存储。
 - 提供显式开启、完全隔离真实数据库的公开只读演示模式。
+- 使用 `error-tracer demo` 无配置、无数据库启动产品演示。
 - 限制请求体大小、浏览器来源、单个对等端速率，并使用常量时间比较凭据。
 - 可构建为单个静态二进制，也可在非 root、只读容器中运行。
 - 自带数据库/程序基准测试和有安全边界的 HTTP 压力测试命令。
+
+## 无配置查看演示
+
+在源码目录直接启动只读产品演示：
+
+```sh
+go run ./cmd/error-tracer demo
+```
+
+然后打开 <http://127.0.0.1:8080/>，Dashboard 会自动进入内置样例工作区。
+该命令不要求采集密钥或管理员令牌，不打开 SQLite，也不会注册事件采集和
+管理问题路由。
+
+也可以使用容器运行同一个隔离演示：
+
+```sh
+docker build -t error-tracer:demo .
+docker run --rm --read-only -p 127.0.0.1:8080:8080 error-tracer:demo demo
+```
 
 ## 使用 Docker Compose 快速启动
 
@@ -173,7 +193,7 @@ Authorization: Bearer 替换为管理员令牌
 | --- | --- | --- | --- |
 | `GET` | `/` | 无 | Dashboard 外壳；读取真实数据仍需管理员令牌 |
 | `GET` | `/assets/error-tracer.js` | 无 | 内嵌浏览器 SDK |
-| `GET` | `/api/v1/meta` | 无 | 公开功能元数据，目前仅包含演示开关 |
+| `GET` | `/api/v1/meta` | 无 | 公开演示可用状态及纯演示模式标记 |
 | `GET` | `/api/v1/demo/issues` | 无，仅演示模式 | 列出内置只读演示问题 |
 | `GET` | `/api/v1/demo/issues/{fingerprint}` | 无，仅演示模式 | 读取一个内置演示问题 |
 | `POST` | `/api/v1/events` | 请求体中的采集密钥 | 提交单个事件 |

--- a/cmd/error-tracer/main.go
+++ b/cmd/error-tracer/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -21,13 +22,18 @@ func main() {
 }
 
 func run() int {
-	if len(os.Args) == 2 && os.Args[1] == "healthcheck" {
-		address := os.Getenv("ERROR_TRACER_ADDRESS")
-		if err := healthcheck.Check(context.Background(), address); err != nil {
-			slog.Error("health check failed", "error", err)
-			return 1
+	if len(os.Args) == 2 {
+		switch os.Args[1] {
+		case "healthcheck":
+			address := os.Getenv("ERROR_TRACER_ADDRESS")
+			if err := healthcheck.Check(context.Background(), address); err != nil {
+				slog.Error("health check failed", "error", err)
+				return 1
+			}
+			return 0
+		case "demo":
+			return runDemo()
 		}
-		return 0
 	}
 
 	cfg, err := config.FromEnvironment()
@@ -59,8 +65,35 @@ func run() int {
 		MetricsEnabled:     cfg.MetricsEnabled,
 	})
 
+	return serve(app, cfg.Address, cfg.ShutdownTimeout, func(ctx context.Context) func() {
+		return startRetention(ctx, issueStore, cfg.ProjectID, cfg.RetentionDays)
+	}, false)
+}
+
+func runDemo() int {
+	address := demoAddress(os.Getenv("ERROR_TRACER_ADDRESS"))
+	app := appserver.New(appserver.Options{DemoOnly: true})
+	return serve(app, address, 10*time.Second, nil, true)
+}
+
+func demoAddress(value string) string {
+	if address := strings.TrimSpace(value); address != "" {
+		return address
+	}
+	return "127.0.0.1:8080"
+}
+
+type backgroundStarter func(context.Context) func()
+
+func serve(
+	app *appserver.Server,
+	address string,
+	shutdownTimeout time.Duration,
+	startBackground backgroundStarter,
+	demoOnly bool,
+) int {
 	httpServer := &http.Server{
-		Addr:              cfg.Address,
+		Addr:              address,
 		Handler:           app.Handler(),
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       10 * time.Second,
@@ -70,20 +103,23 @@ func run() int {
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	stopRetention := startRetention(ctx, issueStore, cfg.ProjectID, cfg.RetentionDays)
-	defer stopRetention()
+	stopBackground := func() {}
+	if startBackground != nil {
+		stopBackground = startBackground(ctx)
+	}
+	defer stopBackground()
 
 	shutdownDone := make(chan struct{})
 	go func() {
 		defer close(shutdownDone)
 		<-ctx.Done()
 		app.SetReady(false)
-		if err := stopHTTPServer(httpServer, cfg.ShutdownTimeout); err != nil {
+		if err := stopHTTPServer(httpServer, shutdownTimeout); err != nil {
 			slog.Error("graceful shutdown failed", "error", err)
 		}
 	}()
 
-	slog.Info("starting Error-Tracer", "address", cfg.Address)
+	slog.Info("starting Error-Tracer", "address", address, "demo_only", demoOnly)
 	if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		slog.Error("server stopped unexpectedly", "error", err)
 		return 1

--- a/cmd/error-tracer/main_test.go
+++ b/cmd/error-tracer/main_test.go
@@ -81,3 +81,12 @@ func TestPruneExpiredIssuesUsesConfiguredWindow(t *testing.T) {
 		t.Fatalf("cutoff = %s, want %s", pruner.cutoff, wantCutoff)
 	}
 }
+
+func TestDemoAddressDefaultsToLoopback(t *testing.T) {
+	if got := demoAddress(""); got != "127.0.0.1:8080" {
+		t.Fatalf("demoAddress() = %q, want loopback default", got)
+	}
+	if got := demoAddress("  :9090  "); got != ":9090" {
+		t.Fatalf("demoAddress() = %q, want trimmed override", got)
+	}
+}

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,5 +1,30 @@
 # Demo mode
 
+## Configuration-free product tour
+
+The shortest path to the sample dashboard is the dedicated demo command:
+
+```sh
+go run ./cmd/error-tracer demo
+```
+
+Open <http://127.0.0.1:8080/>. The dashboard enters the read-only sample
+workspace immediately. Unless `ERROR_TRACER_ADDRESS` is set, the source command
+listens only on loopback.
+
+The same tour can run from the container image:
+
+```sh
+docker build -t error-tracer:demo .
+docker run --rm --read-only -p 127.0.0.1:8080:8080 error-tracer:demo demo
+```
+
+Demo-only startup does not require an ingest key or admin token, does not open
+or create a SQLite database, and does not register the event ingestion or admin
+issue routes. Its in-memory samples reset whenever the process restarts.
+
+## Demo alongside a configured service
+
 Demo mode makes the embedded dashboard useful before a project has submitted
 any real events. It is disabled by default and must be enabled explicitly:
 
@@ -41,6 +66,8 @@ The demo is deliberately separate from production data:
 - Demo handlers never read from or write to the configured SQLite database.
 - Only `GET` list and detail routes exist under `/api/v1/demo/issues`.
 - The normal `/api/v1/issues` routes still require the admin bearer token.
+- In `error-tracer demo` mode, collection and management routes are not
+  registered at all.
 - The dashboard disables status changes while the demo is active.
 - `/api/v1/meta` reveals only whether demo mode is enabled.
 
@@ -52,7 +79,7 @@ that do not need a public product tour.
 
 | Method | Path | Result |
 | --- | --- | --- |
-| `GET` | `/api/v1/meta` | `{"demo_mode":true}` when enabled |
+| `GET` | `/api/v1/meta` | Demo availability; also `"demo_only":true` for the demo command |
 | `GET` | `/api/v1/demo/issues` | Paginated built-in issue list |
 | `GET` | `/api/v1/demo/issues?status=open` | Built-in issues filtered by status |
 | `GET` | `/api/v1/demo/issues/{fingerprint}` | One built-in issue and its latest event |

--- a/internal/server/dashboard/dashboard.js
+++ b/internal/server/dashboard/dashboard.js
@@ -219,6 +219,7 @@
     language: detectLanguage(),
     token: "",
     demo: false,
+    demoOnly: false,
     status: "",
     limit: 25,
     cursor: "",
@@ -571,6 +572,7 @@
     elements.workspace.hidden = false;
     elements.connection.hidden = false;
     elements.demoBanner.hidden = !state.demo;
+    elements.logout.hidden = state.demoOnly;
     updateConnectionLabel();
     showMessage(elements.loginMessage, message("login.noCredentials"), false);
   }
@@ -828,8 +830,9 @@
       }
       const metadata = await response.json();
       const available = metadata.demo_mode === true;
-      elements.demo.hidden = !available;
-      if (available && demoRequested()) {
+      state.demoOnly = metadata.demo_only === true;
+      elements.demo.hidden = !available || state.demoOnly;
+      if (available && (state.demoOnly || demoRequested())) {
         await enterDemo(false);
       } else if (!available && demoRequested()) {
         showMessage(elements.loginMessage, message("errors.demoUnavailable"), true);

--- a/internal/server/dashboard_test.go
+++ b/internal/server/dashboard_test.go
@@ -127,6 +127,7 @@ func TestDashboardScriptAvoidsCredentialPersistenceAndHTMLInjection(t *testing.T
 		`new URLSearchParams(window.location.search).get("demo")`,
 		`searchParams.set("demo", "1")`,
 		`searchParams.delete("demo")`,
+		`metadata.demo_only === true`,
 	} {
 		if !strings.Contains(dashboardScript.body, marker) {
 			t.Fatalf("dashboard script does not contain demo marker %q", marker)

--- a/internal/server/demo.go
+++ b/internal/server/demo.go
@@ -15,6 +15,7 @@ const demoProjectID = "error-tracer-demo"
 
 type publicMetadataResponse struct {
 	DemoMode bool `json:"demo_mode"`
+	DemoOnly bool `json:"demo_only,omitempty"`
 }
 
 type demoFixture struct {
@@ -26,7 +27,10 @@ type demoFixture struct {
 }
 
 func (s *Server) publicMetadata(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusOK, publicMetadataResponse{DemoMode: s.demoStore != nil})
+	writeJSON(w, http.StatusOK, publicMetadataResponse{
+		DemoMode: s.demoStore != nil,
+		DemoOnly: s.demoOnly,
+	})
 }
 
 func (s *Server) listDemoIssues(w http.ResponseWriter, request *http.Request) {

--- a/internal/server/demo_test.go
+++ b/internal/server/demo_test.go
@@ -143,6 +143,54 @@ func TestDemoModeServesIsolatedReadOnlyFixtures(t *testing.T) {
 	}
 }
 
+func TestDemoOnlyModeIsReadyWithoutPrivateServices(t *testing.T) {
+	app := New(Options{DemoOnly: true})
+
+	readyResponse := httptest.NewRecorder()
+	app.Handler().ServeHTTP(
+		readyResponse,
+		httptest.NewRequest(http.MethodGet, "/readyz", nil),
+	)
+	if readyResponse.Code != http.StatusOK {
+		t.Fatalf("readiness status = %d, want %d", readyResponse.Code, http.StatusOK)
+	}
+
+	metadataResponse := httptest.NewRecorder()
+	app.Handler().ServeHTTP(
+		metadataResponse,
+		httptest.NewRequest(http.MethodGet, "/api/v1/meta", nil),
+	)
+	var metadata publicMetadataResponse
+	if err := json.NewDecoder(metadataResponse.Body).Decode(&metadata); err != nil {
+		t.Fatalf("decode metadata: %v", err)
+	}
+	if !metadata.DemoMode || !metadata.DemoOnly {
+		t.Fatalf("metadata = %+v, want demo_mode and demo_only", metadata)
+	}
+
+	demoResponse := httptest.NewRecorder()
+	app.Handler().ServeHTTP(
+		demoResponse,
+		httptest.NewRequest(http.MethodGet, "/api/v1/demo/issues?limit=1", nil),
+	)
+	if demoResponse.Code != http.StatusOK {
+		t.Fatalf("demo status = %d, want %d", demoResponse.Code, http.StatusOK)
+	}
+
+	for _, request := range []*http.Request{
+		httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(`{}`)),
+		httptest.NewRequest(http.MethodPost, "/api/v1/events/batch", strings.NewReader(`{}`)),
+		httptest.NewRequest(http.MethodGet, "/api/v1/issues", nil),
+		httptest.NewRequest(http.MethodPatch, "/api/v1/issues/"+strings.Repeat("0", 64), strings.NewReader(`{}`)),
+	} {
+		response := httptest.NewRecorder()
+		app.Handler().ServeHTTP(response, request)
+		if response.Code != http.StatusNotFound {
+			t.Errorf("%s %s: status = %d, want %d", request.Method, request.URL.Path, response.Code, http.StatusNotFound)
+		}
+	}
+}
+
 func TestDemoListValidatesFilters(t *testing.T) {
 	app := New(Options{
 		Store:      store.NewMemory(),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,6 +15,7 @@ type Server struct {
 	ready          atomic.Bool
 	store          store.Store
 	demoStore      store.Store
+	demoOnly       bool
 	projectID      string
 	ingestKey      string
 	adminTokens    []string
@@ -36,6 +37,7 @@ type Options struct {
 	RatePerMinute      int
 	RateBurst          int
 	DemoMode           bool
+	DemoOnly           bool
 	MetricsEnabled     bool
 }
 
@@ -51,6 +53,7 @@ func New(options Options) *Server {
 	}
 	server := &Server{
 		store:          options.Store,
+		demoOnly:       options.DemoOnly,
 		projectID:      options.ProjectID,
 		ingestKey:      options.IngestKey,
 		adminTokens:    adminTokens,
@@ -59,7 +62,7 @@ func New(options Options) *Server {
 		now:            time.Now,
 		newID:          randomEventID,
 	}
-	if options.DemoMode {
+	if options.DemoMode || options.DemoOnly {
 		server.demoStore = newDemoStore(server.now().UTC())
 	}
 	if options.MetricsEnabled {
@@ -78,18 +81,24 @@ func New(options Options) *Server {
 	mux.HandleFunc("GET /api/v1/meta", server.publicMetadata)
 	mux.HandleFunc("GET /api/v1/demo/issues", server.listDemoIssues)
 	mux.HandleFunc("GET /api/v1/demo/issues/{fingerprint}", server.getDemoIssue)
-	mux.HandleFunc("POST /api/v1/events", server.ingestEventWithOrigin)
-	mux.HandleFunc("OPTIONS /api/v1/events", server.preflightEvent)
-	mux.HandleFunc("POST /api/v1/events/batch", server.ingestBatchWithOrigin)
-	mux.HandleFunc("OPTIONS /api/v1/events/batch", server.preflightEvent)
-	mux.HandleFunc("GET /api/v1/issues", server.listIssues)
-	mux.HandleFunc("GET /api/v1/issues/{fingerprint}", server.getIssue)
-	mux.HandleFunc("PATCH /api/v1/issues/{fingerprint}", server.updateIssue)
+	if !options.DemoOnly {
+		mux.HandleFunc("POST /api/v1/events", server.ingestEventWithOrigin)
+		mux.HandleFunc("OPTIONS /api/v1/events", server.preflightEvent)
+		mux.HandleFunc("POST /api/v1/events/batch", server.ingestBatchWithOrigin)
+		mux.HandleFunc("OPTIONS /api/v1/events/batch", server.preflightEvent)
+		mux.HandleFunc("GET /api/v1/issues", server.listIssues)
+		mux.HandleFunc("GET /api/v1/issues/{fingerprint}", server.getIssue)
+		mux.HandleFunc("PATCH /api/v1/issues/{fingerprint}", server.updateIssue)
+	}
 	server.handler = mux
 	if server.metrics != nil {
 		server.handler = server.metrics.middleware(mux)
 	}
-	server.ready.Store(options.Store != nil && options.ProjectID != "" && options.IngestKey != "" && options.AdminToken != "")
+	ready := options.Store != nil && options.ProjectID != "" && options.IngestKey != "" && options.AdminToken != ""
+	if options.DemoOnly {
+		ready = server.demoStore != nil
+	}
+	server.ready.Store(ready)
 	return server
 }
 


### PR DESCRIPTION
## Summary

- add `error-tracer demo` as a zero-configuration, database-free product tour
- bind the source-run command to `127.0.0.1:8080` by default while honoring `ERROR_TRACER_ADDRESS`
- mark demo-only instances ready from their isolated in-memory fixture store
- auto-open the embedded dashboard's sample workspace and hide the irrelevant disconnect action
- do not register event ingestion or admin issue routes in demo-only mode
- expose a backward-compatible `demo_only` metadata flag only when active
- document source and read-only container commands in both READMEs and the demo guide

## Runtime verification

- started the binary with no credentials: `/tmp/error-tracer-demo-test demo`
- `/readyz` returned `200` and `/api/v1/meta` returned `{"demo_mode":true,"demo_only":true}`
- the sample issue API returned fixtures
- private ingestion and management routes returned `404`
- no `.db`, `.db-wal`, or `.db-shm` files were created

## Automated verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `npm test`
- `git diff --check`