### PR TITLE
feat: batch browser SDK delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,22 @@ The service exposes its embedded SDK at `/assets/error-tracer.js`:
 ```
 
 Automatic capture is enabled by default. Set `autoCapture: false` when only
-manual capture is wanted. The client also supports `sampleRate`,
-`maxEventsPerMinute`, `beforeSend`, and a custom `transport`.
+manual capture is wanted. Events are queued in memory and sent to the atomic
+batch endpoint when 10 events have accumulated, after 1 second, or when the
+page is hidden. The queue retains at most 100 events and failed batches are
+retried twice with exponential backoff. These bounds can be changed with
+`batchSize`, `flushInterval`, `maxQueueSize`, `maxRetries`,
+`retryBaseDelay`, and `maxBatchBytes`.
+
+Call `await tracer.flush()` before a controlled shutdown when delivery should
+be observed, and use `tracer.getStats()` to inspect queued, sent, retried,
+failed, and dropped counts. A successful `captureMessage` or
+`captureException` means that a partial batch was accepted into the local
+queue; `flush()` reports whether every batch in that flush was accepted by the
+transport. The client also supports `sampleRate`, `maxEventsPerMinute`,
+`beforeSend`, `batchEndpoint`, and a custom batch `transport`. Use
+`beforeSend` to remove application-specific sensitive values before an event
+enters the queue.
 
 ## Ingestion API
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -100,7 +100,17 @@ Compose 使用名为 `error-tracer-data` 的卷保存 `error-tracer.db`。
 ```
 
 默认自动捕获错误。如果只需要手动上报，可设置 `autoCapture: false`。客户端还
-支持 `sampleRate`、`maxEventsPerMinute`、`beforeSend` 和自定义 `transport`。
+会先在内存中排队，并在累计 10 个事件、等待 1 秒或页面隐藏时，将事件发送到
+原子批量接口。队列最多保留 100 个事件；失败的批次采用指数退避，最多重试
+2 次。可通过 `batchSize`、`flushInterval`、`maxQueueSize`、`maxRetries`、
+`retryBaseDelay` 和 `maxBatchBytes` 调整这些边界。
+
+在可控的页面关闭流程中，可调用 `await tracer.flush()` 并检查返回值；
+`tracer.getStats()` 可查看排队、成功、重试、失败和丢弃数量。
+`captureMessage` 或 `captureException` 成功只表示未满批次已进入本地队列，
+`flush()` 才表示本轮所有批次是否都被传输层接受。客户端还支持
+`sampleRate`、`maxEventsPerMinute`、`beforeSend`、`batchEndpoint` 和自定义
+批量 `transport`。事件进入队列前，可使用 `beforeSend` 删除业务特有的敏感值。
 
 ## 采集 API
 

--- a/sdk/error-tracer.js
+++ b/sdk/error-tracer.js
@@ -60,6 +60,20 @@
       if (options.autoCapture !== undefined && typeof options.autoCapture !== "boolean") {
         throw new TypeError("ErrorTracer autoCapture must be a boolean");
       }
+      this.batchSize = integerOption(options.batchSize, 10, 1, 100, "batchSize");
+      this.flushInterval = integerOption(
+        options.flushInterval, 1000, 0, 60_000, "flushInterval",
+      );
+      this.maxQueueSize = integerOption(
+        options.maxQueueSize, 100, this.batchSize, 1000, "maxQueueSize",
+      );
+      this.maxRetries = integerOption(options.maxRetries, 2, 0, 5, "maxRetries");
+      this.retryBaseDelay = integerOption(
+        options.retryBaseDelay, 250, 1, 10_000, "retryBaseDelay",
+      );
+      this.maxBatchBytes = integerOption(
+        options.maxBatchBytes, 512 * 1024, 1024, 900 * 1024, "maxBatchBytes",
+      );
 
       this.release = truncateUTF8(cleanString(options.release), LIMITS.release);
       this.environment = truncateUTF8(cleanString(options.environment), LIMITS.environment);
@@ -68,10 +82,28 @@
       this.random = typeof options.random === "function" ? options.random : Math.random;
       this.clock = typeof options.clock === "function" ? options.clock : () => new Date();
       this.sentAt = [];
-      this.transport = options.transport || defaultTransport(this.runtime, this.endpoint);
+      this.batchEndpoint = cleanString(
+        options.batchEndpoint || defaultBatchEndpoint(this.endpoint),
+      );
+      if (!this.batchEndpoint) {
+        throw new TypeError("ErrorTracer batchEndpoint is required");
+      }
+      this.transport = options.transport ||
+        defaultTransport(this.runtime, this.batchEndpoint);
+      this.queue = [];
+      this.flushTimer = null;
+      this.flushPromise = null;
+      this.stats = {
+        sent: 0,
+        dropped: 0,
+        failed: 0,
+        batches: 0,
+        retries: 0,
+      };
       this.installed = false;
       this.errorListener = (event) => this.captureWindowError(event);
       this.rejectionListener = (event) => this.captureUnhandledRejection(event);
+      this.pagehideListener = () => this.settle(this.flush());
       if (options.autoCapture !== false) {
         this.install();
       }
@@ -87,18 +119,20 @@
       }
       this.runtime.addEventListener("error", this.errorListener, true);
       this.runtime.addEventListener("unhandledrejection", this.rejectionListener, false);
+      this.runtime.addEventListener("pagehide", this.pagehideListener, false);
       this.installed = true;
       return true;
     }
 
     destroy() {
-      if (!this.installed) {
-        return;
-      }
-      if (this.runtime && typeof this.runtime.removeEventListener === "function") {
+      if (this.installed && this.runtime &&
+          typeof this.runtime.removeEventListener === "function") {
         this.runtime.removeEventListener("error", this.errorListener, true);
         this.runtime.removeEventListener("unhandledrejection", this.rejectionListener, false);
+        this.runtime.removeEventListener("pagehide", this.pagehideListener, false);
       }
+      this.clearFlushTimer();
+      this.settle(this.flush());
       this.installed = false;
     }
 
@@ -230,15 +264,15 @@
       }
       captured.occurred_at = validISODate(captured.occurred_at) || now.toISOString();
 
-      const payload = { project_key: this.projectKey, event: captured };
-      const body = JSON.stringify(payload);
-      try {
-        return Promise.resolve(this.transport(body, payload))
-          .then((result) => result !== false)
-          .catch(() => false);
-      } catch (_) {
-        return Promise.resolve(false);
+      this.enqueue(captured);
+      if (this.queue.length >= this.batchSize) {
+        if (this.flushPromise) {
+          return Promise.resolve(true);
+        }
+        return this.flush();
       }
+      this.scheduleFlush();
+      return Promise.resolve(true);
     }
 
     normalize(candidate) {
@@ -295,6 +329,166 @@
       this.sentAt.push(now);
       return true;
     }
+
+    enqueue(captured) {
+      if (this.queue.length >= this.maxQueueSize) {
+        this.queue.shift();
+        this.stats.dropped++;
+      }
+      this.queue.push(cloneEvent(captured));
+    }
+
+    flush() {
+      if (this.flushPromise) {
+        return this.flushPromise;
+      }
+      this.clearFlushTimer();
+      if (!this.queue.length) {
+        return Promise.resolve(true);
+      }
+      const pending = this.queue.splice(0);
+      this.flushPromise = this.sendPending(pending).finally(() => {
+        this.flushPromise = null;
+        if (this.queue.length >= this.batchSize) {
+          this.settle(this.flush());
+        } else {
+          this.scheduleFlush();
+        }
+      });
+      return this.flushPromise;
+    }
+
+    sendPending(pending) {
+      const batches = this.makeBatches(pending);
+      return batches.reduce(
+        (result, events) => result.then((accepted) =>
+          this.sendBatch(events, 0).then((batchAccepted) => accepted && batchAccepted)),
+        Promise.resolve(true),
+      );
+    }
+
+    makeBatches(pending) {
+      const batches = [];
+      let current = [];
+      for (const captured of pending) {
+        const candidate = current.concat([captured]);
+        const candidateBody = JSON.stringify({
+          project_key: this.projectKey,
+          events: candidate,
+        });
+        if (current.length && utf8Length(candidateBody) > this.maxBatchBytes) {
+          batches.push(current);
+          current = [captured];
+        } else {
+          current = candidate;
+        }
+        if (current.length >= this.batchSize) {
+          batches.push(current);
+          current = [];
+        }
+      }
+      if (current.length) {
+        batches.push(current);
+      }
+      return batches;
+    }
+
+    sendBatch(events, attempt) {
+      const payload = { project_key: this.projectKey, events };
+      const body = JSON.stringify(payload);
+      let result;
+      try {
+        result = Promise.resolve(this.transport(body, payload));
+      } catch (_) {
+        result = Promise.reject(new Error("transport failed"));
+      }
+      return result.then(
+        (accepted) => accepted === false
+          ? this.retryBatch(events, attempt)
+          : this.acceptBatch(events),
+        () => this.retryBatch(events, attempt),
+      );
+    }
+
+    acceptBatch(events) {
+      this.stats.sent += events.length;
+      this.stats.batches++;
+      return true;
+    }
+
+    retryBatch(events, attempt) {
+      if (attempt < this.maxRetries) {
+        this.stats.retries++;
+        const delay = this.retryBaseDelay * (2 ** attempt);
+        return this.wait(delay).then(() => this.sendBatch(events, attempt + 1));
+      }
+      this.stats.failed += events.length;
+      this.stats.dropped += events.length;
+      return false;
+    }
+
+    wait(delay) {
+      const setTimer = safeRead(this.runtime, "setTimeout");
+      if (typeof setTimer !== "function") {
+        return Promise.resolve();
+      }
+      return new Promise((resolve) => {
+        setTimer.call(this.runtime, resolve, delay);
+      });
+    }
+
+    scheduleFlush() {
+      if (this.flushTimer !== null || !this.queue.length || this.flushInterval === 0) {
+        return;
+      }
+      const setTimer = safeRead(this.runtime, "setTimeout");
+      if (typeof setTimer !== "function") {
+        return;
+      }
+      this.flushTimer = setTimer.call(this.runtime, () => {
+        this.flushTimer = null;
+        this.settle(this.flush());
+      }, this.flushInterval);
+      if (this.flushTimer && typeof this.flushTimer.unref === "function") {
+        this.flushTimer.unref();
+      }
+    }
+
+    clearFlushTimer() {
+      if (this.flushTimer === null) {
+        return;
+      }
+      const clearTimer = safeRead(this.runtime, "clearTimeout");
+      if (typeof clearTimer === "function") {
+        clearTimer.call(this.runtime, this.flushTimer);
+      }
+      this.flushTimer = null;
+    }
+
+    getStats() {
+      return Object.freeze({
+        queued: this.queue.length,
+        sent: this.stats.sent,
+        dropped: this.stats.dropped,
+        failed: this.stats.failed,
+        batches: this.stats.batches,
+        retries: this.stats.retries,
+      });
+    }
+  }
+
+  function defaultBatchEndpoint(endpoint) {
+    const suffixIndex = endpoint.search(/[?#]/);
+    const path = suffixIndex < 0 ? endpoint : endpoint.slice(0, suffixIndex);
+    const parameters = suffixIndex < 0 ? "" : endpoint.slice(suffixIndex);
+    const suffix = "/api/v1/events";
+    if (path.endsWith(suffix + "/batch")) {
+      return path + parameters;
+    }
+    if (path.endsWith(suffix)) {
+      return path + "/batch" + parameters;
+    }
+    return path.replace(/\/$/, "") + "/batch" + parameters;
   }
 
   function defaultTransport(runtime, endpoint) {
@@ -325,6 +519,16 @@
         keepalive: true,
       }).then((response) => Boolean(response && response.ok));
     };
+  }
+
+  function integerOption(value, fallback, minimum, maximum, name) {
+    value = value === undefined ? fallback : Number(value);
+    if (!Number.isInteger(value) || value < minimum || value > maximum) {
+      throw new TypeError(
+        `ErrorTracer ${name} must be an integer between ${minimum} and ${maximum}`,
+      );
+    }
+    return value;
   }
 
   function errorDetails(error) {

--- a/sdk/error-tracer.test.js
+++ b/sdk/error-tracer.test.js
@@ -22,6 +22,17 @@ test("validates client options", () => {
   assert.throws(() => ErrorTracer.init({ projectKey: PROJECT_KEY, beforeSend: true }), /beforeSend/);
   assert.throws(() => ErrorTracer.init({ projectKey: PROJECT_KEY, transport: true }), /transport/);
   assert.throws(() => ErrorTracer.init({ projectKey: PROJECT_KEY, autoCapture: "yes" }), /autoCapture/);
+  assert.throws(() => ErrorTracer.init({ projectKey: PROJECT_KEY, batchSize: 0 }), /batchSize/);
+  assert.throws(() => ErrorTracer.init({ projectKey: PROJECT_KEY, batchSize: 101 }), /batchSize/);
+  assert.throws(() => ErrorTracer.init({ projectKey: PROJECT_KEY, flushInterval: -1 }), /flushInterval/);
+  assert.throws(() => ErrorTracer.init({
+    projectKey: PROJECT_KEY, batchSize: 10, maxQueueSize: 9,
+  }), /maxQueueSize/);
+  assert.throws(() => ErrorTracer.init({ projectKey: PROJECT_KEY, maxRetries: 6 }), /maxRetries/);
+  assert.throws(() => ErrorTracer.init({ projectKey: PROJECT_KEY, maxBatchBytes: 1023 }), /maxBatchBytes/);
+  assert.throws(() => ErrorTracer.init({
+    projectKey: PROJECT_KEY, maxBatchBytes: (900 * 1024) + 1,
+  }), /maxBatchBytes/);
 
   assert.ok(ErrorTracer.init({
     projectKey: "界".repeat(6),
@@ -48,6 +59,7 @@ test("captures and normalizes an exception", async () => {
     tags: { region: " ap-southeast-1 " },
     random: () => 0,
     clock: () => FIXED_TIME,
+    batchSize: 1,
     transport(nextBody, nextPayload) {
       body = nextBody;
       payload = nextPayload;
@@ -67,7 +79,7 @@ test("captures and normalizes an exception", async () => {
   assert.equal(accepted, true);
   assert.deepEqual(JSON.parse(body), payload);
   assert.equal(payload.project_key, PROJECT_KEY);
-  assert.deepEqual(payload.event, {
+  assert.deepEqual(payload.events, [{
     kind: "error",
     message: "boom",
     stack: "Error: boom\n    at checkout (app.js:10:5)",
@@ -82,7 +94,7 @@ test("captures and normalizes an exception", async () => {
       region: "ap-southeast-1",
       operation: "checkout",
     },
-  });
+  }]);
 });
 
 test("captures messages and bounds UTF-8 fields", async () => {
@@ -94,7 +106,7 @@ test("captures messages and bounds UTF-8 fields", async () => {
       Array.from({ length: 40 }, (_, index) => [`tag-${index}`, "界".repeat(100)]),
     ),
     transport(_body, payload) {
-      events.push(payload.event);
+      events.push(payload.events[0]);
       return true;
     },
   });
@@ -122,7 +134,7 @@ test("beforeSend can modify or drop an event", async () => {
       return event;
     },
     transport(_body, payload) {
-      events.push(payload.event);
+      events.push(payload.events[0]);
       return true;
     },
   });
@@ -194,12 +206,13 @@ test("default transport prefers sendBeacon with a simple text body", async () =>
     endpoint: "https://errors.example/api/v1/events",
     random: () => 0,
     clock: () => FIXED_TIME,
+    batchSize: 1,
   });
 
   assert.equal(await client.captureMessage("boom"), true);
-  assert.equal(beacon.endpoint, "https://errors.example/api/v1/events");
+  assert.equal(beacon.endpoint, "https://errors.example/api/v1/events/batch");
   assert.equal(beacon.blob.type, "text/plain;charset=UTF-8");
-  assert.equal(JSON.parse(beacon.blob.parts[0]).event.message, "boom");
+  assert.equal(JSON.parse(beacon.blob.parts[0]).events[0].message, "boom");
   assert.equal(fetchCalled, false);
 });
 
@@ -223,15 +236,16 @@ test("default transport falls back to credential-free fetch", async () => {
     runtime,
     random: () => 0,
     clock: () => FIXED_TIME,
+    batchSize: 1,
   });
 
   assert.equal(await client.captureMessage("boom"), true);
-  assert.equal(request.endpoint, "/api/v1/events");
+  assert.equal(request.endpoint, "/api/v1/events/batch");
   assert.equal(request.options.method, "POST");
   assert.deepEqual(request.options.headers, { "Content-Type": "application/json" });
   assert.equal(request.options.credentials, "omit");
   assert.equal(request.options.keepalive, true);
-  assert.equal(JSON.parse(request.options.body).event.message, "boom");
+  assert.equal(JSON.parse(request.options.body).events[0].message, "boom");
 });
 
 test("capture contains extension and transport failures", async () => {
@@ -272,8 +286,9 @@ test("automatically captures runtime, resource, and rejection failures", async (
     runtime,
     random: () => 0,
     clock: () => FIXED_TIME,
+    batchSize: 1,
     transport(_body, payload) {
-      events.push(payload.event);
+      events.push(payload.events[0]);
       return true;
     },
   });
@@ -329,12 +344,14 @@ test("automatic capture can be installed and destroyed idempotently", () => {
   assert.equal(client.install(), false);
   assert.equal(runtime.listenerCount("error"), 1);
   assert.equal(runtime.listenerCount("unhandledrejection"), 1);
+  assert.equal(runtime.listenerCount("pagehide"), 1);
 
   client.destroy();
   client.destroy();
   assert.equal(client.installed, false);
   assert.equal(runtime.listenerCount("error"), 0);
   assert.equal(runtime.listenerCount("unhandledrejection"), 0);
+  assert.equal(runtime.listenerCount("pagehide"), 0);
 });
 
 test("serializes plain-object rejection reasons", async () => {
@@ -345,8 +362,9 @@ test("serializes plain-object rejection reasons", async () => {
     runtime,
     random: () => 0,
     clock: () => FIXED_TIME,
+    batchSize: 1,
     transport(_body, payload) {
-      events.push(payload.event);
+      events.push(payload.events[0]);
       return true;
     },
   });
@@ -361,12 +379,168 @@ test("serializes plain-object rejection reasons", async () => {
   assert.equal(events[0].message, '{"code":"E_CHECKOUT","retryable":false}');
 });
 
+test("queues events and sends an atomic batch", async () => {
+  const payloads = [];
+  const client = testClient({
+    batchSize: 2,
+    flushInterval: 0,
+    transport(_body, payload) {
+      payloads.push(payload);
+      return true;
+    },
+  });
+
+  assert.equal(await client.captureMessage("one"), true);
+  assert.deepEqual(client.getStats(), {
+    queued: 1, sent: 0, dropped: 0, failed: 0, batches: 0, retries: 0,
+  });
+  assert.equal(await client.captureMessage("two"), true);
+  assert.equal(payloads.length, 1);
+  assert.deepEqual(payloads[0].events.map((item) => item.message), ["one", "two"]);
+  assert.deepEqual(client.getStats(), {
+    queued: 0, sent: 2, dropped: 0, failed: 0, batches: 1, retries: 0,
+  });
+});
+
+test("splits a queue before the configured request-size limit", async () => {
+  const payloads = [];
+  const client = testClient({
+    batchSize: 10,
+    flushInterval: 0,
+    maxBatchBytes: 1024,
+    transport(_body, payload) {
+      payloads.push(payload);
+      return true;
+    },
+  });
+
+  assert.equal(await client.captureMessage("a".repeat(700)), true);
+  assert.equal(await client.captureMessage("b".repeat(700)), true);
+  assert.equal(await client.flush(), true);
+  assert.equal(payloads.length, 2);
+  assert.deepEqual(payloads.map((payload) => payload.events.length), [1, 1]);
+});
+
+test("flushes a partial queue after the configured interval", async () => {
+  let scheduled;
+  const payloads = [];
+  const runtime = {
+    location: { href: "https://app.example/page" },
+    setTimeout(callback, delay) {
+      scheduled = { callback, delay };
+      return 1;
+    },
+    clearTimeout() {},
+  };
+  const client = testClient({
+    runtime,
+    batchSize: 10,
+    flushInterval: 75,
+    transport(_body, payload) {
+      payloads.push(payload);
+      return true;
+    },
+  });
+
+  assert.equal(await client.captureMessage("scheduled"), true);
+  assert.equal(scheduled.delay, 75);
+  scheduled.callback();
+  await eventLoopTurn();
+  assert.equal(payloads.length, 1);
+  assert.equal(payloads[0].events[0].message, "scheduled");
+});
+
+test("bounds the queue while another batch is in flight", async () => {
+  let releaseFirst;
+  const payloads = [];
+  const firstDelivery = new Promise((resolve) => {
+    releaseFirst = resolve;
+  });
+  const client = testClient({
+    batchSize: 1,
+    maxQueueSize: 2,
+    flushInterval: 0,
+    transport(_body, payload) {
+      payloads.push(payload);
+      return payloads.length === 1 ? firstDelivery : true;
+    },
+  });
+
+  const firstCapture = client.captureMessage("one");
+  assert.equal(await client.captureMessage("two"), true);
+  assert.equal(await client.captureMessage("three"), true);
+  assert.equal(await client.captureMessage("four"), true);
+  assert.equal(client.getStats().dropped, 1);
+
+  releaseFirst(true);
+  assert.equal(await firstCapture, true);
+  await eventLoopTurn();
+  assert.equal(await client.flush(), true);
+  assert.deepEqual(
+    payloads.flatMap((payload) => payload.events.map((event) => event.message)),
+    ["one", "three", "four"],
+  );
+  assert.deepEqual(client.getStats(), {
+    queued: 0, sent: 3, dropped: 1, failed: 0, batches: 3, retries: 0,
+  });
+});
+
+test("retries failed batches with a finite budget", async () => {
+  let attempts = 0;
+  const runtime = {
+    location: { href: "https://app.example/page" },
+    setTimeout(callback) {
+      callback();
+      return 1;
+    },
+    clearTimeout() {},
+  };
+  const client = testClient({
+    runtime,
+    batchSize: 1,
+    maxRetries: 2,
+    retryBaseDelay: 1,
+    transport() {
+      attempts++;
+      return false;
+    },
+  });
+
+  assert.equal(await client.captureMessage("offline"), false);
+  assert.equal(attempts, 3);
+  assert.deepEqual(client.getStats(), {
+    queued: 0, sent: 0, dropped: 1, failed: 1, batches: 0, retries: 2,
+  });
+});
+
+test("pagehide flushes a partial queue", async () => {
+  const payloads = [];
+  const runtime = fakeRuntime();
+  const client = testClient({
+    runtime,
+    batchSize: 10,
+    flushInterval: 0,
+    transport(_body, payload) {
+      payloads.push(payload);
+      return true;
+    },
+  });
+
+  assert.equal(await client.captureMessage("leaving"), true);
+  assert.equal(payloads.length, 0);
+  runtime.dispatch("pagehide", {});
+  await eventLoopTurn();
+  assert.equal(payloads.length, 1);
+  assert.equal(payloads[0].events[0].message, "leaving");
+});
+
 function testClient(overrides) {
   return ErrorTracer.init({
     projectKey: PROJECT_KEY,
     runtime: { location: { href: "https://app.example/page" } },
     random: () => 0,
     clock: () => FIXED_TIME,
+    batchSize: 1,
     transport() {
       return true;
     },


### PR DESCRIPTION
## Summary

- send browser events to the atomic batch endpoint by default
- bound queued events, batch size, and serialized request size
- flush on batch completion, a configurable timer, `pagehide`, or an explicit `flush()`
- retry failed batches with a finite exponential-backoff budget
- expose delivery counters through `getStats()`
- document delivery semantics and privacy filtering in English and Simplified Chinese

## Compatibility

A custom `transport` now receives a batch payload (`{ project_key, events }`). Applications that provide a custom transport should update it before adopting this change.

## Verification

- `npm test` (17 tests)
- `node --check sdk/error-tracer.js`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`