### PR TITLE
fix: prevent malformed URLs from retaining secrets

### DIFF
--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -194,7 +194,10 @@ func sanitizeURL(value string) string {
 	}
 	parsed, err := url.Parse(value)
 	if err != nil {
-		return value
+		// Never persist an unparseable client-controlled URL. In particular,
+		// malformed percent escapes can otherwise preserve userinfo, queries,
+		// and fragments that the normal parsed path removes.
+		return ""
 	}
 	parsed.User = nil
 	parsed.RawQuery = ""

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -37,6 +37,41 @@ func TestNormalizeRemovesSensitiveURLComponents(t *testing.T) {
 	}
 }
 
+func TestNormalizeDropsMalformedURLs(t *testing.T) {
+	captured := Event{
+		Kind:      KindError,
+		Message:   "failed",
+		SourceURL: "https://user:secret@example.com/%zz?token=secret#fragment",
+		PageURL:   "https://example.com/%zz?session=secret#fragment",
+	}
+
+	captured.Normalize()
+
+	if captured.SourceURL != "" || captured.PageURL != "" {
+		t.Fatalf(
+			"malformed URLs survived normalization: source=%q page=%q",
+			captured.SourceURL, captured.PageURL,
+		)
+	}
+	if err := captured.Validate(); err != nil {
+		t.Fatalf("Validate() returned %v after dropping optional malformed URLs", err)
+	}
+}
+
+func TestNormalizeRejectsMalformedResourceURL(t *testing.T) {
+	captured := Event{
+		Kind:      KindResourceError,
+		SourceURL: "https://user:secret@example.com/%zz?token=secret#fragment",
+	}
+	captured.Normalize()
+
+	err := captured.Validate()
+	var validationErr *ValidationError
+	if !errors.As(err, &validationErr) || validationErr.Field != "source_url" {
+		t.Fatalf("Validate() error = %v, want source_url validation error", err)
+	}
+}
+
 func TestNormalizeResolvesTagKeyCollisionsDeterministically(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

- drop client-controlled URLs that cannot be parsed safely
- prevent malformed percent escapes from preserving credentials, queries, or fragments
- reject resource-error events once their required malformed source URL is removed

## Verification

- `go test ./internal/event ./internal/server`
- `git diff --check`

Addresses the unresolved URL sanitization findings from PRs #7 and #32.