### PR TITLE
fix: avoid global-capacity allocations in the memory store

### DIFF
--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -210,7 +210,7 @@ func (m *Memory) ListIssues(ctx context.Context, projectID string, options ListO
 	options = normalizeListOptions(options)
 
 	m.mu.RLock()
-	issues := make([]Issue, 0, len(m.issues))
+	issues := make([]Issue, 0)
 	for _, issue := range m.issues {
 		if issue.ProjectID == projectID &&
 			(options.Status == "" || issue.Status == options.Status) {

--- a/internal/store/memory_test.go
+++ b/internal/store/memory_test.go
@@ -104,6 +104,29 @@ func TestMemorySeparatesProjects(t *testing.T) {
 	}
 }
 
+func TestMemoryListIssuesDoesNotRetainUnrelatedProjectCapacity(t *testing.T) {
+	memory := NewMemory()
+	base := time.Date(2026, time.August, 29, 1, 0, 0, 0, time.UTC)
+	for index := range 100 {
+		captured := testEvent(base.Add(time.Duration(index) * time.Minute))
+		captured.Message = fmt.Sprintf("unrelated-%d", index)
+		if _, err := memory.Record(context.Background(), "project-a", captured); err != nil {
+			t.Fatalf("record unrelated event %d: %v", index, err)
+		}
+	}
+
+	page, err := memory.ListIssues(context.Background(), "project-b", ListOptions{})
+	if err != nil {
+		t.Fatalf("list empty project: %v", err)
+	}
+	if len(page.Issues) != 0 || cap(page.Issues) != 0 {
+		t.Fatalf(
+			"empty project issues length/capacity = %d/%d, want 0/0",
+			len(page.Issues), cap(page.Issues),
+		)
+	}
+}
+
 func TestMemoryListIssuesIsBoundedAndOrdered(t *testing.T) {
 	memory := NewMemory()
 	base := time.Date(2026, time.August, 29, 1, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary

- stop sizing project-scoped issue lists from the global issue count
- keep empty-project responses from retaining backing capacity for unrelated projects
- add a regression test with 100 unrelated issues

## Verification

- `go test ./internal/store`
- `git diff --check`

Addresses the unresolved memory-store allocation finding from PR #8.