### PR TITLE
fix: return 413 for oversized trailing JSON data

### DIFF
--- a/internal/server/ingest.go
+++ b/internal/server/ingest.go
@@ -62,8 +62,7 @@ func (s *Server) ingestEvent(w http.ResponseWriter, request *http.Request) {
 
 	var payload ingestRequest
 	if err := decoder.Decode(&payload); err != nil {
-		var tooLarge *http.MaxBytesError
-		if errors.As(err, &tooLarge) {
+		if bodyLimitExceeded(err) {
 			writeJSON(w, http.StatusRequestEntityTooLarge, errorResponse{Error: "event_too_large"})
 			return
 		}
@@ -71,6 +70,10 @@ func (s *Server) ingestEvent(w http.ResponseWriter, request *http.Request) {
 		return
 	}
 	if err := ensureJSONEnd(decoder); err != nil {
+		if bodyLimitExceeded(err) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, errorResponse{Error: "event_too_large"})
+			return
+		}
 		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid_json"})
 		return
 	}
@@ -124,8 +127,7 @@ func (s *Server) ingestBatch(w http.ResponseWriter, request *http.Request) {
 
 	var payload batchIngestRequest
 	if err := decoder.Decode(&payload); err != nil {
-		var tooLarge *http.MaxBytesError
-		if errors.As(err, &tooLarge) {
+		if bodyLimitExceeded(err) {
 			writeJSON(w, http.StatusRequestEntityTooLarge, errorResponse{Error: "batch_too_large"})
 			return
 		}
@@ -133,6 +135,10 @@ func (s *Server) ingestBatch(w http.ResponseWriter, request *http.Request) {
 		return
 	}
 	if err := ensureJSONEnd(decoder); err != nil {
+		if bodyLimitExceeded(err) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, errorResponse{Error: "batch_too_large"})
+			return
+		}
 		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid_json"})
 		return
 	}
@@ -221,6 +227,11 @@ func ensureJSONEnd(decoder *json.Decoder) error {
 		return errors.New("multiple JSON values")
 	}
 	return err
+}
+
+func bodyLimitExceeded(err error) bool {
+	var tooLarge *http.MaxBytesError
+	return errors.As(err, &tooLarge)
 }
 
 func constantTimeEqual(left, right string) bool {

--- a/internal/server/ingest_test.go
+++ b/internal/server/ingest_test.go
@@ -266,6 +266,53 @@ func TestIngestEventRejectsOversizedBody(t *testing.T) {
 	}
 }
 
+func TestIngestEndpointsRejectOversizedTrailingData(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		body      string
+		limit     int
+		wantError string
+	}{
+		{
+			name:      "single event",
+			path:      "/api/v1/events",
+			body:      `{"project_key":"0123456789abcdef","event":{"kind":"error","message":"boom"}}`,
+			limit:     maxEventBodySize,
+			wantError: "event_too_large",
+		},
+		{
+			name:      "event batch",
+			path:      "/api/v1/events/batch",
+			body:      `{"project_key":"0123456789abcdef","events":[{"kind":"error","message":"boom"}]}`,
+			limit:     maxBatchBodySize,
+			wantError: "batch_too_large",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			body := test.body + strings.Repeat(" ", test.limit)
+			request := httptest.NewRequest(http.MethodPost, test.path, strings.NewReader(body))
+			request.Header.Set("Content-Type", "application/json")
+			response := httptest.NewRecorder()
+
+			newTestServer().Handler().ServeHTTP(response, request)
+
+			if response.Code != http.StatusRequestEntityTooLarge {
+				t.Fatalf("status = %d, want %d; body = %s", response.Code, http.StatusRequestEntityTooLarge, response.Body.String())
+			}
+			var result errorResponse
+			if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if result.Error != test.wantError {
+				t.Fatalf("error = %q, want %q", result.Error, test.wantError)
+			}
+		})
+	}
+}
+
 func TestIngestEventRejectsUnconfiguredServer(t *testing.T) {
 	app := New(Options{})
 	request := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(`{}`))

--- a/internal/server/issues.go
+++ b/internal/server/issues.go
@@ -131,8 +131,7 @@ func (s *Server) updateIssue(w http.ResponseWriter, request *http.Request) {
 	decoder.DisallowUnknownFields()
 	var payload issueUpdateRequest
 	if err := decoder.Decode(&payload); err != nil {
-		var tooLarge *http.MaxBytesError
-		if errors.As(err, &tooLarge) {
+		if bodyLimitExceeded(err) {
 			writeJSON(w, http.StatusRequestEntityTooLarge, errorResponse{Error: "request_too_large"})
 			return
 		}
@@ -140,6 +139,10 @@ func (s *Server) updateIssue(w http.ResponseWriter, request *http.Request) {
 		return
 	}
 	if err := ensureJSONEnd(decoder); err != nil {
+		if bodyLimitExceeded(err) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, errorResponse{Error: "request_too_large"})
+			return
+		}
 		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid_json"})
 		return
 	}

--- a/internal/server/issues_test.go
+++ b/internal/server/issues_test.go
@@ -470,6 +470,28 @@ func TestUpdateIssueRejectsInvalidRequests(t *testing.T) {
 	}
 }
 
+func TestUpdateIssueRejectsOversizedTrailingData(t *testing.T) {
+	fingerprint := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	body := `{"status":"open"}` + strings.Repeat(" ", maxIssueUpdateBodySize)
+	request := authorizedRequest(http.MethodPatch, "/api/v1/issues/"+fingerprint)
+	request.Header.Set("Content-Type", "application/json")
+	request.Body = io.NopCloser(strings.NewReader(body))
+	response := httptest.NewRecorder()
+
+	newTestServer().Handler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d; body = %s", response.Code, http.StatusRequestEntityTooLarge, response.Body.String())
+	}
+	var result errorResponse
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result.Error != "request_too_large" {
+		t.Fatalf("error = %q, want request_too_large", result.Error)
+	}
+}
+
 func authorizedRequest(method, target string) *http.Request {
 	request := httptest.NewRequest(method, target, nil)
 	request.Header.Set("Authorization", "Bearer "+testAdminToken)


### PR DESCRIPTION
## Summary

- preserve `MaxBytesError` after the first JSON value has decoded successfully
- return each endpoint's documented 413 error for oversized trailing whitespace or values
- cover single-event ingestion, batch ingestion, and issue status updates

## Verification

- `go test ./internal/server`
- `git diff --check`

Addresses the unresolved request-limit findings from PRs #9 and #13, including the equivalent batch endpoint path.