### PR TITLE
fix: canonicalize default ports in allowed origins

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"strconv"
@@ -193,7 +194,18 @@ func parseOrigins(value string) ([]string, error) {
 		if parsed.User != nil || (parsed.Path != "" && parsed.Path != "/") || parsed.RawQuery != "" || parsed.Fragment != "" {
 			return nil, fmt.Errorf("ERROR_TRACER_ALLOWED_ORIGINS value %q must not contain credentials, a path, query, or fragment", raw)
 		}
-		origin := scheme + "://" + strings.ToLower(parsed.Host)
+		hostname := strings.ToLower(parsed.Hostname())
+		port := parsed.Port()
+		if (scheme == "http" && port == "80") || (scheme == "https" && port == "443") {
+			port = ""
+		}
+		host := hostname
+		if port != "" {
+			host = net.JoinHostPort(hostname, port)
+		} else if strings.Contains(hostname, ":") {
+			host = "[" + hostname + "]"
+		}
+		origin := scheme + "://" + host
 		if _, exists := seen[origin]; exists {
 			continue
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -257,6 +257,29 @@ func TestFromEnvironmentRejectsInvalidOrigins(t *testing.T) {
 	}
 }
 
+func TestParseOriginsRemovesDefaultPorts(t *testing.T) {
+	origins, err := parseOrigins(strings.Join([]string{
+		"https://app.example.com:443",
+		"https://app.example.com",
+		"http://localhost:80",
+		"http://localhost",
+		"https://app.example.com:8443",
+		"http://[::1]:80",
+	}, ","))
+	if err != nil {
+		t.Fatalf("parseOrigins() error = %v", err)
+	}
+	want := []string{
+		"https://app.example.com",
+		"http://localhost",
+		"https://app.example.com:8443",
+		"http://[::1]",
+	}
+	if !reflect.DeepEqual(origins, want) {
+		t.Fatalf("parseOrigins() = %#v, want %#v", origins, want)
+	}
+}
+
 func TestFromEnvironmentRejectsInvalidRateLimits(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

- normalize `https:443` and `http:80` to the browser-serialized origin form
- preserve explicit non-default ports
- retain correct bracketed IPv6 origin formatting
- deduplicate explicit and implicit default-port entries

## Verification

- `go test ./internal/config ./internal/server`
- `git diff --check`

Addresses the unresolved origin canonicalization finding from PR #14.