### PR TITLE
fix: harden browser SDK delivery guarantees

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,21 @@ retried twice with exponential backoff. These bounds can be changed with
 `batchSize`, `flushInterval`, `maxQueueSize`, `maxRetries`,
 `retryBaseDelay`, and `maxBatchBytes`.
 
+`maxBatchBytes` defaults to 60 KiB so unload-time requests stay within the
+portable `sendBeacon`/fetch keepalive budget. A larger custom value is allowed,
+but payloads above that keepalive budget use a normal fetch and therefore need
+an explicit `await tracer.flush()` when delivery must be observed. An event
+that cannot fit in its own configured batch is dropped and counted in the
+client statistics instead of being sent as an oversized request.
+
 Call `await tracer.flush()` before a controlled shutdown when delivery should
 be observed, and use `tracer.getStats()` to inspect queued, sent, retried,
 failed, and dropped counts. A successful `captureMessage` or
 `captureException` means that a partial batch was accepted into the local
 queue; `flush()` reports whether every batch in that flush was accepted by the
-transport. The client also supports `sampleRate`, `maxEventsPerMinute`,
+transport. If another flush is already active, the returned promise also waits
+for events that were queued when `flush()` was called. The client also supports
+`sampleRate`, `maxEventsPerMinute`,
 `beforeSend`, `batchEndpoint`, and a custom batch `transport`. Use
 `beforeSend` to remove application-specific sensitive values before an event
 enters the queue.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ retried twice with exponential backoff. These bounds can be changed with
 `batchSize`, `flushInterval`, `maxQueueSize`, `maxRetries`,
 `retryBaseDelay`, and `maxBatchBytes`.
 
+The queue bound includes snapshots waiting behind an active transport. An
+event already being delivered is excluded, but repeated timer or explicit
+flushes cannot create an unbounded chained backlog. `getStats().queued` reports
+both the ordinary queue and those reserved snapshots.
+
 `maxBatchBytes` defaults to 60 KiB so unload-time requests stay within the
 portable `sendBeacon`/fetch keepalive budget. A larger custom value is allowed,
 but payloads above that keepalive budget use a normal fetch and therefore need

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -112,6 +112,10 @@ Compose 使用名为 `error-tracer-data` 的卷保存 `error-tracer.db`。
 2 次。可通过 `batchSize`、`flushInterval`、`maxQueueSize`、`maxRetries`、
 `retryBaseDelay` 和 `maxBatchBytes` 调整这些边界。
 
+队列上限包含等待当前传输完成的已保留快照；正在传输的事件本身不计入该上限，
+但重复的定时或显式 flush 无法形成无界的链式积压。`getStats().queued` 会同时统计
+普通队列和这些已保留快照。
+
 `maxBatchBytes` 默认为 60 KiB，以满足不同浏览器对 `sendBeacon`/fetch
 keepalive 请求体的通用限制。可以配置更大的值，但超过 keepalive 边界的载荷
 会改用普通 fetch；如果必须确认送达，需要显式执行 `await tracer.flush()`。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -112,10 +112,17 @@ Compose 使用名为 `error-tracer-data` 的卷保存 `error-tracer.db`。
 2 次。可通过 `batchSize`、`flushInterval`、`maxQueueSize`、`maxRetries`、
 `retryBaseDelay` 和 `maxBatchBytes` 调整这些边界。
 
+`maxBatchBytes` 默认为 60 KiB，以满足不同浏览器对 `sendBeacon`/fetch
+keepalive 请求体的通用限制。可以配置更大的值，但超过 keepalive 边界的载荷
+会改用普通 fetch；如果必须确认送达，需要显式执行 `await tracer.flush()`。
+单个事件若无法放入自身的批次，会直接丢弃并计入客户端统计，而不会发送超限
+请求。
+
 在可控的页面关闭流程中，可调用 `await tracer.flush()` 并检查返回值；
 `tracer.getStats()` 可查看排队、成功、重试、失败和丢弃数量。
 `captureMessage` 或 `captureException` 成功只表示未满批次已进入本地队列，
-`flush()` 才表示本轮所有批次是否都被传输层接受。客户端还支持
+`flush()` 才表示本轮所有批次是否都被传输层接受。如果已有 flush 正在执行，
+返回的 Promise 还会等待调用 `flush()` 时已排队的事件。客户端还支持
 `sampleRate`、`maxEventsPerMinute`、`beforeSend`、`batchEndpoint` 和自定义
 批量 `transport`。事件进入队列前，可使用 `beforeSend` 删除业务特有的敏感值。
 

--- a/sdk/error-tracer.js
+++ b/sdk/error-tracer.js
@@ -395,10 +395,7 @@
         this.reservedCount += pending.length;
       }
       const send = () => {
-        if (active) {
-          this.reservedCount -= pending.length;
-        }
-        return this.sendPending(pending);
+        return this.sendPending(pending, Boolean(active));
       };
       const delivery = active
         ? active.then(
@@ -422,15 +419,22 @@
       return tracked;
     }
 
-    sendPending(pending) {
+    sendPending(pending, reserved) {
       const grouped = this.makeBatches(pending);
       if (grouped.rejected) {
+        if (reserved) {
+          this.reservedCount -= grouped.rejected;
+        }
         this.stats.failed += grouped.rejected;
         this.stats.dropped += grouped.rejected;
       }
       return grouped.batches.reduce(
-        (result, events) => result.then((accepted) =>
-          this.sendBatch(events, 0).then((batchAccepted) => accepted && batchAccepted)),
+        (result, events) => result.then((accepted) => {
+          if (reserved) {
+            this.reservedCount -= events.length;
+          }
+          return this.sendBatch(events, 0).then((batchAccepted) => accepted && batchAccepted);
+        }),
         Promise.resolve(grouped.rejected === 0),
       );
     }

--- a/sdk/error-tracer.js
+++ b/sdk/error-tracer.js
@@ -428,9 +428,15 @@
         this.stats.failed += grouped.rejected;
         this.stats.dropped += grouped.rejected;
       }
+
+      if (!reserved) {
+        for (const events of grouped.batches.slice(1)) {
+          this.reservedCount += events.length;
+        }
+      }
       return grouped.batches.reduce(
-        (result, events) => result.then((accepted) => {
-          if (reserved) {
+        (result, events, index) => result.then((accepted) => {
+          if (reserved || index > 0) {
             this.reservedCount -= events.length;
           }
           return this.sendBatch(events, 0).then((batchAccepted) => accepted && batchAccepted);

--- a/sdk/error-tracer.js
+++ b/sdk/error-tracer.js
@@ -92,6 +92,7 @@
       this.transport = options.transport ||
         defaultTransport(this.runtime, this.batchEndpoint);
       this.queue = [];
+      this.reservedCount = 0;
       this.flushTimer = null;
       this.flushPromise = null;
       this.stats = {
@@ -305,7 +306,9 @@
         return Promise.resolve(false);
       }
 
-      this.enqueue(captured);
+      if (!this.enqueue(captured)) {
+        return Promise.resolve(false);
+      }
       if (this.queue.length >= this.batchSize) {
         if (this.flushPromise) {
           return Promise.resolve(true);
@@ -375,11 +378,16 @@
     }
 
     enqueue(captured) {
-      if (this.queue.length >= this.maxQueueSize) {
+      if (this.queue.length + this.reservedCount >= this.maxQueueSize) {
+        if (!this.queue.length) {
+          this.stats.dropped++;
+          return false;
+        }
         this.queue.shift();
         this.stats.dropped++;
       }
       this.queue.push(cloneEvent(captured));
+      return true;
     }
 
     flush() {
@@ -389,10 +397,21 @@
       }
       const pending = this.queue.splice(0);
       const active = this.flushPromise;
+      if (active) {
+        this.reservedCount += pending.length;
+      }
+      const send = () => {
+        if (active) {
+          this.reservedCount -= pending.length;
+        }
+        return this.sendPending(pending);
+      };
       const delivery = active
-        ? active.then((accepted) =>
-          this.sendPending(pending).then((drained) => accepted && drained))
-        : this.sendPending(pending);
+        ? active.then(
+          (accepted) => send().then((drained) => accepted && drained),
+          () => send().then(() => false),
+        )
+        : send();
       let tracked;
       tracked = delivery.finally(() => {
         if (this.flushPromise !== tracked) {
@@ -543,7 +562,7 @@
 
     getStats() {
       return Object.freeze({
-        queued: this.queue.length,
+        queued: this.queue.length + this.reservedCount,
         sent: this.stats.sent,
         dropped: this.stats.dropped,
         failed: this.stats.failed,

--- a/sdk/error-tracer.js
+++ b/sdk/error-tracer.js
@@ -22,6 +22,7 @@
   });
   const KEEPALIVE_BODY_LIMIT = 60 * 1024;
   const EVENT_KINDS = new Set(["error", "unhandled_rejection", "resource_error"]);
+  const parseJSON = JSON.parse;
 
   class Client {
     constructor(options) {
@@ -753,10 +754,36 @@
       envelope.project_key = projectKey;
       envelope.events = serializedEvents;
       const serialized = JSON.stringify(envelope);
-      return typeof serialized === "string" ? serialized : null;
+      if (typeof serialized !== "string") {
+        return null;
+      }
+      return sameJSONValue(parseJSON(serialized), envelope) ? serialized : null;
     } catch (_) {
       return null;
     }
+  }
+
+  function sameJSONValue(actual, expected) {
+    if (actual === expected) {
+      return true;
+    }
+    if (!actual || !expected || typeof actual !== "object" || typeof expected !== "object") {
+      return false;
+    }
+    if (Array.isArray(actual) !== Array.isArray(expected)) {
+      return false;
+    }
+    const actualKeys = Object.keys(actual);
+    const expectedKeys = Object.keys(expected);
+    if (actualKeys.length !== expectedKeys.length) {
+      return false;
+    }
+    for (const key of expectedKeys) {
+      if (!actualKeys.includes(key) || !sameJSONValue(actual[key], expected[key])) {
+        return false;
+      }
+    }
+    return true;
   }
 
   function safeRead(value, property) {

--- a/sdk/error-tracer.js
+++ b/sdk/error-tracer.js
@@ -454,7 +454,11 @@
         const candidate = current.concat([captured]);
         const candidateBody = safeSerialize(this.projectKey, candidate);
         if (candidateBody === null) {
-          rejected++;
+          if (current.length) {
+            batches.push(current);
+            current = [];
+          }
+          batches.push([captured]);
           continue;
         }
         if (utf8Length(candidateBody) > this.maxBatchBytes) {
@@ -464,7 +468,10 @@
           }
           batches.push(current);
           const singleBody = safeSerialize(this.projectKey, [captured]);
-          if (singleBody === null || utf8Length(singleBody) > this.maxBatchBytes) {
+          if (singleBody === null) {
+            batches.push([captured]);
+            current = [];
+          } else if (utf8Length(singleBody) > this.maxBatchBytes) {
             rejected++;
             current = [];
           } else {
@@ -489,6 +496,11 @@
       const body = safeSerialize(this.projectKey, events);
       if (body === null) {
         return this.retryBatch(events, attempt);
+      }
+      if (utf8Length(body) > this.maxBatchBytes) {
+        this.stats.failed += events.length;
+        this.stats.dropped += events.length;
+        return Promise.resolve(false);
       }
       let result;
       try {

--- a/sdk/error-tracer.js
+++ b/sdk/error-tracer.js
@@ -383,20 +383,21 @@
     }
 
     flush() {
-      if (this.flushPromise) {
-        const active = this.flushPromise;
-        if (!this.queue.length) {
-          return active;
-        }
-        return active.then((accepted) =>
-          this.flush().then((drained) => accepted && drained));
-      }
       this.clearFlushTimer();
       if (!this.queue.length) {
-        return Promise.resolve(true);
+        return this.flushPromise || Promise.resolve(true);
       }
       const pending = this.queue.splice(0);
-      this.flushPromise = this.sendPending(pending).finally(() => {
+      const active = this.flushPromise;
+      const delivery = active
+        ? active.then((accepted) =>
+          this.sendPending(pending).then((drained) => accepted && drained))
+        : this.sendPending(pending);
+      let tracked;
+      tracked = delivery.finally(() => {
+        if (this.flushPromise !== tracked) {
+          return;
+        }
         this.flushPromise = null;
         if (this.queue.length >= this.batchSize) {
           this.settle(this.flush());
@@ -404,7 +405,8 @@
           this.scheduleFlush();
         }
       });
-      return this.flushPromise;
+      this.flushPromise = tracked;
+      return tracked;
     }
 
     sendPending(pending) {

--- a/sdk/error-tracer.js
+++ b/sdk/error-tracer.js
@@ -20,6 +20,7 @@
     tagKey: 64,
     tagValue: 256,
   });
+  const KEEPALIVE_BODY_LIMIT = 60 * 1024;
   const EVENT_KINDS = new Set(["error", "unhandled_rejection", "resource_error"]);
 
   class Client {
@@ -72,7 +73,7 @@
         options.retryBaseDelay, 250, 1, 10_000, "retryBaseDelay",
       );
       this.maxBatchBytes = integerOption(
-        options.maxBatchBytes, 512 * 1024, 1024, 900 * 1024, "maxBatchBytes",
+        options.maxBatchBytes, KEEPALIVE_BODY_LIMIT, 1024, 900 * 1024, "maxBatchBytes",
       );
 
       this.release = truncateUTF8(cleanString(options.release), LIMITS.release);
@@ -104,6 +105,12 @@
       this.errorListener = (event) => this.captureWindowError(event);
       this.rejectionListener = (event) => this.captureUnhandledRejection(event);
       this.pagehideListener = () => this.settle(this.flush());
+      this.visibilityTarget = safeRead(this.runtime, "document") || null;
+      this.visibilityListener = () => {
+        if (safeRead(this.visibilityTarget, "visibilityState") === "hidden") {
+          this.settle(this.flush());
+        }
+      };
       if (options.autoCapture !== false) {
         this.install();
       }
@@ -117,9 +124,30 @@
           typeof this.runtime.removeEventListener !== "function") {
         return false;
       }
-      this.runtime.addEventListener("error", this.errorListener, true);
-      this.runtime.addEventListener("unhandledrejection", this.rejectionListener, false);
-      this.runtime.addEventListener("pagehide", this.pagehideListener, false);
+      const installed = [];
+      try {
+        this.runtime.addEventListener("error", this.errorListener, true);
+        installed.push([this.runtime, "error", this.errorListener, true]);
+        this.runtime.addEventListener("unhandledrejection", this.rejectionListener, false);
+        installed.push([this.runtime, "unhandledrejection", this.rejectionListener, false]);
+        this.runtime.addEventListener("pagehide", this.pagehideListener, false);
+        installed.push([this.runtime, "pagehide", this.pagehideListener, false]);
+        if (this.visibilityTarget &&
+            typeof safeRead(this.visibilityTarget, "addEventListener") === "function" &&
+            typeof safeRead(this.visibilityTarget, "removeEventListener") === "function") {
+          this.visibilityTarget.addEventListener(
+            "visibilitychange", this.visibilityListener, false,
+          );
+          installed.push([
+            this.visibilityTarget, "visibilitychange", this.visibilityListener, false,
+          ]);
+        }
+      } catch (_) {
+        for (const registration of installed.reverse()) {
+          removeListener(...registration);
+        }
+        return false;
+      }
       this.installed = true;
       return true;
     }
@@ -127,9 +155,12 @@
     destroy() {
       if (this.installed && this.runtime &&
           typeof this.runtime.removeEventListener === "function") {
-        this.runtime.removeEventListener("error", this.errorListener, true);
-        this.runtime.removeEventListener("unhandledrejection", this.rejectionListener, false);
-        this.runtime.removeEventListener("pagehide", this.pagehideListener, false);
+        removeListener(this.runtime, "error", this.errorListener, true);
+        removeListener(this.runtime, "unhandledrejection", this.rejectionListener, false);
+        removeListener(this.runtime, "pagehide", this.pagehideListener, false);
+        removeListener(
+          this.visibilityTarget, "visibilitychange", this.visibilityListener, false,
+        );
       }
       this.clearFlushTimer();
       this.settle(this.flush());
@@ -227,7 +258,7 @@
 
       let captured;
       try {
-        captured = this.normalize(candidate);
+        captured = this.normalize(candidate, true);
       } catch (_) {
         return Promise.resolve(false);
       }
@@ -244,7 +275,7 @@
           return Promise.resolve(false);
         }
         try {
-          captured = this.normalize(captured);
+          captured = this.normalize(captured, false);
         } catch (_) {
           return Promise.resolve(false);
         }
@@ -275,7 +306,7 @@
       return Promise.resolve(true);
     }
 
-    normalize(candidate) {
+    normalize(candidate, applyDefaults) {
       if (!candidate || typeof candidate !== "object") {
         return null;
       }
@@ -293,10 +324,9 @@
         return null;
       }
 
-      const pageURL = truncateUTF8(
-        scrubURL(safeRead(candidate, "page_url") || readLocation(this.runtime), this.runtime),
-        LIMITS.url,
-      );
+      const pageValue = safeRead(candidate, "page_url") ||
+        (applyDefaults ? readLocation(this.runtime) : "");
+      const pageURL = truncateUTF8(scrubURL(pageValue, this.runtime), LIMITS.url);
       return compactObject({
         kind,
         message,
@@ -307,14 +337,18 @@
         column: nonNegativeInteger(safeRead(candidate, "column")),
         occurred_at: validISODate(safeRead(candidate, "occurred_at")),
         release: truncateUTF8(
-          cleanString(safeRead(candidate, "release") || this.release),
+          cleanString(safeRead(candidate, "release") || (applyDefaults ? this.release : "")),
           LIMITS.release,
         ),
         environment: truncateUTF8(
-          cleanString(safeRead(candidate, "environment") || this.environment),
+          cleanString(
+            safeRead(candidate, "environment") || (applyDefaults ? this.environment : ""),
+          ),
           LIMITS.environment,
         ),
-        tags: normalizeTags(mergeTags(this.tags, safeRead(candidate, "tags"))),
+        tags: normalizeTags(applyDefaults
+          ? mergeTags(this.tags, safeRead(candidate, "tags"))
+          : safeRead(candidate, "tags")),
       });
     }
 
@@ -340,7 +374,12 @@
 
     flush() {
       if (this.flushPromise) {
-        return this.flushPromise;
+        const active = this.flushPromise;
+        if (!this.queue.length) {
+          return active;
+        }
+        return active.then((accepted) =>
+          this.flush().then((drained) => accepted && drained));
       }
       this.clearFlushTimer();
       if (!this.queue.length) {
@@ -359,26 +398,48 @@
     }
 
     sendPending(pending) {
-      const batches = this.makeBatches(pending);
-      return batches.reduce(
+      const grouped = this.makeBatches(pending);
+      if (grouped.rejected) {
+        this.stats.failed += grouped.rejected;
+        this.stats.dropped += grouped.rejected;
+      }
+      return grouped.batches.reduce(
         (result, events) => result.then((accepted) =>
           this.sendBatch(events, 0).then((batchAccepted) => accepted && batchAccepted)),
-        Promise.resolve(true),
+        Promise.resolve(grouped.rejected === 0),
       );
     }
 
     makeBatches(pending) {
       const batches = [];
       let current = [];
+      let rejected = 0;
       for (const captured of pending) {
         const candidate = current.concat([captured]);
-        const candidateBody = JSON.stringify({
+        const candidateBody = safeSerialize({
           project_key: this.projectKey,
           events: candidate,
         });
-        if (current.length && utf8Length(candidateBody) > this.maxBatchBytes) {
+        if (candidateBody === null) {
+          rejected++;
+          continue;
+        }
+        if (utf8Length(candidateBody) > this.maxBatchBytes) {
+          if (!current.length) {
+            rejected++;
+            continue;
+          }
           batches.push(current);
-          current = [captured];
+          const singleBody = safeSerialize({
+            project_key: this.projectKey,
+            events: [captured],
+          });
+          if (singleBody === null || utf8Length(singleBody) > this.maxBatchBytes) {
+            rejected++;
+            current = [];
+          } else {
+            current = [captured];
+          }
         } else {
           current = candidate;
         }
@@ -390,12 +451,15 @@
       if (current.length) {
         batches.push(current);
       }
-      return batches;
+      return { batches, rejected };
     }
 
     sendBatch(events, attempt) {
       const payload = { project_key: this.projectKey, events };
-      const body = JSON.stringify(payload);
+      const body = safeSerialize(payload);
+      if (body === null) {
+        return this.retryBatch(events, attempt);
+      }
       let result;
       try {
         result = Promise.resolve(this.transport(body, payload));
@@ -493,10 +557,12 @@
 
   function defaultTransport(runtime, endpoint) {
     return function send(body) {
+      const keepalive = utf8Length(body) <= KEEPALIVE_BODY_LIMIT;
       const navigator = safeRead(runtime, "navigator");
       const BlobConstructor = safeRead(runtime, "Blob");
       const sendBeacon = safeRead(navigator, "sendBeacon");
-      if (typeof sendBeacon === "function" && typeof BlobConstructor === "function") {
+      if (keepalive && typeof sendBeacon === "function" &&
+          typeof BlobConstructor === "function") {
         try {
           const blob = new BlobConstructor([body], { type: "text/plain;charset=UTF-8" });
           if (sendBeacon.call(navigator, endpoint, blob)) {
@@ -516,7 +582,7 @@
         headers: { "Content-Type": "application/json" },
         body,
         credentials: "omit",
-        keepalive: true,
+        keepalive,
       }).then((response) => Boolean(response && response.ok));
     };
   }
@@ -622,6 +688,25 @@
       return location ? cleanString(safeRead(location, "href")) : "";
     } catch (_) {
       return "";
+    }
+  }
+
+  function removeListener(target, type, listener, options) {
+    try {
+      const remove = safeRead(target, "removeEventListener");
+      if (typeof remove === "function") {
+        remove.call(target, type, listener, options);
+      }
+    } catch (_) {
+      // Listener cleanup is best-effort and must not escape into the host page.
+    }
+  }
+
+  function safeSerialize(value) {
+    try {
+      return JSON.stringify(value);
+    } catch (_) {
+      return null;
     }
   }
 

--- a/sdk/error-tracer.js
+++ b/sdk/error-tracer.js
@@ -293,10 +293,7 @@
       }
       captured.occurred_at = validISODate(captured.occurred_at) || now.toISOString();
 
-      const singleBody = safeSerialize({
-        project_key: this.projectKey,
-        events: [captured],
-      });
+      const singleBody = safeSerialize(this.projectKey, [captured]);
       if (singleBody === null || utf8Length(singleBody) > this.maxBatchBytes) {
         this.stats.failed++;
         this.stats.dropped++;
@@ -444,10 +441,7 @@
       let rejected = 0;
       for (const captured of pending) {
         const candidate = current.concat([captured]);
-        const candidateBody = safeSerialize({
-          project_key: this.projectKey,
-          events: candidate,
-        });
+        const candidateBody = safeSerialize(this.projectKey, candidate);
         if (candidateBody === null) {
           rejected++;
           continue;
@@ -458,10 +452,7 @@
             continue;
           }
           batches.push(current);
-          const singleBody = safeSerialize({
-            project_key: this.projectKey,
-            events: [captured],
-          });
+          const singleBody = safeSerialize(this.projectKey, [captured]);
           if (singleBody === null || utf8Length(singleBody) > this.maxBatchBytes) {
             rejected++;
             current = [];
@@ -484,7 +475,7 @@
 
     sendBatch(events, attempt) {
       const payload = { project_key: this.projectKey, events };
-      const body = safeSerialize(payload);
+      const body = safeSerialize(this.projectKey, events);
       if (body === null) {
         return this.retryBatch(events, attempt);
       }
@@ -730,9 +721,28 @@
     }
   }
 
-  function safeSerialize(value) {
+  function safeSerialize(projectKey, events) {
     try {
-      const serialized = JSON.stringify(value);
+      const serializedEvents = events.map((value) => {
+        const captured = Object.create(null);
+        for (const [key, item] of Object.entries(value)) {
+          if (key === "tags" && item && typeof item === "object") {
+            const tags = Object.create(null);
+            for (const [tagKey, tagValue] of Object.entries(item)) {
+              tags[tagKey] = tagValue;
+            }
+            captured[key] = tags;
+          } else {
+            captured[key] = item;
+          }
+        }
+        return captured;
+      });
+      Object.defineProperty(serializedEvents, "toJSON", { value: undefined });
+      const envelope = Object.create(null);
+      envelope.project_key = projectKey;
+      envelope.events = serializedEvents;
+      const serialized = JSON.stringify(envelope);
       return typeof serialized === "string" ? serialized : null;
     } catch (_) {
       return null;

--- a/sdk/error-tracer.js
+++ b/sdk/error-tracer.js
@@ -302,13 +302,14 @@
         this.stats.dropped++;
         return Promise.resolve(false);
       }
-      if (!this.consumeBudget(now.getTime())) {
+      if (!this.hasBudget(now.getTime())) {
         return Promise.resolve(false);
       }
 
       if (!this.enqueue(captured)) {
         return Promise.resolve(false);
       }
+      this.sentAt.push(now.getTime());
       if (this.queue.length >= this.batchSize) {
         if (this.flushPromise) {
           return Promise.resolve(true);
@@ -365,16 +366,12 @@
       });
     }
 
-    consumeBudget(now) {
+    hasBudget(now) {
       const cutoff = now - 60_000;
       while (this.sentAt.length && this.sentAt[0] <= cutoff) {
         this.sentAt.shift();
       }
-      if (this.sentAt.length >= this.maxEventsPerMinute) {
-        return false;
-      }
-      this.sentAt.push(now);
-      return true;
+      return this.sentAt.length < this.maxEventsPerMinute;
     }
 
     enqueue(captured) {
@@ -735,7 +732,8 @@
 
   function safeSerialize(value) {
     try {
-      return JSON.stringify(value);
+      const serialized = JSON.stringify(value);
+      return typeof serialized === "string" ? serialized : null;
     } catch (_) {
       return null;
     }

--- a/sdk/error-tracer.test.js
+++ b/sdk/error-tracer.test.js
@@ -697,8 +697,10 @@ test("flush reserves the events queued when it is called", async () => {
   const firstCapture = client.captureMessage("one");
   assert.equal(await client.captureMessage("two"), true);
   const flush = client.flush();
-  assert.equal(await client.captureMessage("three"), true);
-  assert.equal(client.getStats().dropped, 0);
+  assert.equal(await client.captureMessage("three"), false);
+  assert.deepEqual(client.getStats(), {
+    queued: 1, sent: 0, dropped: 1, failed: 0, batches: 0, retries: 0,
+  });
 
   releaseFirst(true);
   assert.equal(await firstCapture, true);
@@ -707,9 +709,48 @@ test("flush reserves the events queued when it is called", async () => {
   assert.equal(await client.flush(), true);
   assert.deepEqual(
     payloads.flatMap((payload) => payload.events.map((event) => event.message)),
-    ["one", "two", "three"],
+    ["one", "two"],
   );
-  assert.equal(client.getStats().dropped, 0);
+  assert.equal(client.getStats().dropped, 1);
+});
+
+test("bounds snapshots reserved behind a stalled delivery", async () => {
+  let releaseFirst;
+  const payloads = [];
+  const firstDelivery = new Promise((resolve) => {
+    releaseFirst = resolve;
+  });
+  const client = testClient({
+    batchSize: 3,
+    maxQueueSize: 3,
+    flushInterval: 0,
+    transport(_body, payload) {
+      payloads.push(payload);
+      return payloads.length === 1 ? firstDelivery : true;
+    },
+  });
+
+  assert.equal(await client.captureMessage("one"), true);
+  const firstFlush = client.flush();
+  for (const message of ["two", "three", "four"]) {
+    assert.equal(await client.captureMessage(message), true);
+    client.flush();
+  }
+  assert.equal(await client.captureMessage("five"), false);
+  assert.deepEqual(client.getStats(), {
+    queued: 3, sent: 0, dropped: 1, failed: 0, batches: 0, retries: 0,
+  });
+
+  releaseFirst(true);
+  assert.equal(await firstFlush, true);
+  assert.equal(await client.flush(), true);
+  assert.deepEqual(
+    payloads.flatMap((payload) => payload.events.map((event) => event.message)),
+    ["one", "two", "three", "four"],
+  );
+  assert.deepEqual(client.getStats(), {
+    queued: 0, sent: 4, dropped: 1, failed: 0, batches: 4, retries: 0,
+  });
 });
 
 test("retries failed batches with a finite budget", async () => {

--- a/sdk/error-tracer.test.js
+++ b/sdk/error-tracer.test.js
@@ -393,6 +393,53 @@ test("capture rejects serialized bodies without the expected envelope", async ()
   assert.equal(transports, 0);
 });
 
+test("retries events when grouping serialization temporarily fails", async () => {
+  const original = JSON.stringify;
+  const payloads = [];
+  let retryCallback;
+  const client = testClient({
+    runtime: {
+      location: { href: "https://app.example/page" },
+      setTimeout(callback) {
+        retryCallback = callback;
+        return 1;
+      },
+      clearTimeout() {},
+    },
+    batchSize: 3,
+    flushInterval: 0,
+    retryBaseDelay: 1,
+    transport(_body, payload) {
+      payloads.push(payload);
+      return true;
+    },
+  });
+  assert.equal(await client.captureMessage("one"), true);
+  assert.equal(await client.captureMessage("two"), true);
+
+  let delivery;
+  try {
+    JSON.stringify = () => { throw new Error("temporarily unavailable"); };
+    delivery = client.flush();
+    await eventLoopTurn();
+    const releaseRetry = retryCallback;
+    JSON.stringify = original;
+    assert.equal(typeof releaseRetry, "function");
+    releaseRetry();
+  } finally {
+    JSON.stringify = original;
+  }
+
+  assert.equal(await delivery, true);
+  assert.deepEqual(
+    payloads.flatMap((payload) => payload.events.map((event) => event.message)),
+    ["one", "two"],
+  );
+  assert.deepEqual(client.getStats(), {
+    queued: 0, sent: 2, dropped: 0, failed: 0, batches: 2, retries: 1,
+  });
+});
+
 test("batch serialization ignores inherited toJSON hooks", async () => {
   const original = Object.prototype.toJSON;
   const bodies = [];

--- a/sdk/error-tracer.test.js
+++ b/sdk/error-tracer.test.js
@@ -809,6 +809,59 @@ test("bounds snapshots reserved behind a stalled delivery", async () => {
   });
 });
 
+test("keeps unsent sub-batches reserved behind a stalled sub-batch", async () => {
+  let releaseFirst;
+  let releaseSecond;
+  const deliveries = [
+    new Promise((resolve) => { releaseFirst = resolve; }),
+    new Promise((resolve) => { releaseSecond = resolve; }),
+  ];
+  const payloads = [];
+  const client = testClient({
+    batchSize: 2,
+    maxQueueSize: 3,
+    flushInterval: 0,
+    transport(_body, payload) {
+      payloads.push(payload);
+      return deliveries[payloads.length - 1] || true;
+    },
+  });
+
+  assert.equal(await client.captureMessage("one"), true);
+  const firstFlush = client.captureMessage("two");
+  for (const message of ["three", "four", "five"]) {
+    assert.equal(await client.captureMessage(message), true);
+  }
+  const pendingFlush = client.flush();
+
+  releaseFirst(true);
+  assert.equal(await firstFlush, true);
+  await eventLoopTurn();
+  assert.deepEqual(
+    payloads.map((payload) => payload.events.map((event) => event.message)),
+    [["one", "two"], ["three", "four"]],
+  );
+  assert.equal(client.getStats().queued, 1);
+
+  for (const message of ["six", "seven", "eight"]) {
+    assert.equal(await client.captureMessage(message), true);
+  }
+  assert.deepEqual(client.getStats(), {
+    queued: 3, sent: 2, dropped: 1, failed: 0, batches: 1, retries: 0,
+  });
+
+  releaseSecond(true);
+  assert.equal(await pendingFlush, true);
+  assert.equal(await client.flush(), true);
+  assert.deepEqual(
+    payloads.flatMap((payload) => payload.events.map((event) => event.message)),
+    ["one", "two", "three", "four", "five", "seven", "eight"],
+  );
+  assert.deepEqual(client.getStats(), {
+    queued: 0, sent: 7, dropped: 1, failed: 0, batches: 4, retries: 0,
+  });
+});
+
 test("retries failed batches with a finite budget", async () => {
   let attempts = 0;
   const runtime = {

--- a/sdk/error-tracer.test.js
+++ b/sdk/error-tracer.test.js
@@ -357,6 +357,31 @@ test("capture contains JSON serialization failures", async () => {
   assert.equal(result, false);
 });
 
+test("capture rejects a non-string JSON serialization result", async () => {
+  const original = Object.prototype.toJSON;
+  let result;
+  let transports = 0;
+  try {
+    Object.prototype.toJSON = function omitSerialization() {
+      return undefined;
+    };
+    result = await testClient({
+      transport() {
+        transports++;
+        return true;
+      },
+    }).captureMessage("boom");
+  } finally {
+    if (original === undefined) {
+      delete Object.prototype.toJSON;
+    } else {
+      Object.prototype.toJSON = original;
+    }
+  }
+  assert.equal(result, false);
+  assert.equal(transports, 0);
+});
+
 test("automatically captures runtime, resource, and rejection failures", async () => {
   const events = [];
   const runtime = fakeRuntime();
@@ -687,6 +712,7 @@ test("flush reserves the events queued when it is called", async () => {
   const client = testClient({
     batchSize: 1,
     maxQueueSize: 1,
+    maxEventsPerMinute: 3,
     flushInterval: 0,
     transport(_body, payload) {
       payloads.push(payload);
@@ -712,6 +738,11 @@ test("flush reserves the events queued when it is called", async () => {
     ["one", "two"],
   );
   assert.equal(client.getStats().dropped, 1);
+  assert.equal(await client.captureMessage("four"), true);
+  assert.deepEqual(
+    payloads.flatMap((payload) => payload.events.map((event) => event.message)),
+    ["one", "two", "four"],
+  );
 });
 
 test("bounds snapshots reserved behind a stalled delivery", async () => {

--- a/sdk/error-tracer.test.js
+++ b/sdk/error-tracer.test.js
@@ -862,6 +862,49 @@ test("keeps unsent sub-batches reserved behind a stalled sub-batch", async () =>
   });
 });
 
+test("keeps initial unsent sub-batches reserved behind a stalled sub-batch", async () => {
+  let releaseFirst;
+  const firstDelivery = new Promise((resolve) => { releaseFirst = resolve; });
+  const payloads = [];
+  const client = testClient({
+    batchSize: 3,
+    maxQueueSize: 3,
+    maxBatchBytes: 1024,
+    flushInterval: 0,
+    transport(_body, payload) {
+      payloads.push(payload);
+      return payloads.length === 1 ? firstDelivery : true;
+    },
+  });
+  const large = (label) => `${label}:${"x".repeat(700)}`;
+  const messages = ["one", "two", "three", "four", "five", "six"].map(large);
+
+  assert.equal(await client.captureMessage(messages[0]), true);
+  assert.equal(await client.captureMessage(messages[1]), true);
+  const initialFlush = client.captureMessage(messages[2]);
+  await eventLoopTurn();
+  assert.deepEqual(payloads.map((payload) => payload.events.length), [1]);
+  assert.equal(client.getStats().queued, 2);
+
+  for (const message of messages.slice(3)) {
+    assert.equal(await client.captureMessage(message), true);
+  }
+  assert.deepEqual(client.getStats(), {
+    queued: 3, sent: 0, dropped: 2, failed: 0, batches: 0, retries: 0,
+  });
+
+  releaseFirst(true);
+  assert.equal(await initialFlush, true);
+  assert.equal(await client.flush(), true);
+  assert.deepEqual(
+    payloads.flatMap((payload) => payload.events.map((event) => event.message)),
+    [messages[0], messages[1], messages[2], messages[5]],
+  );
+  assert.deepEqual(client.getStats(), {
+    queued: 0, sent: 4, dropped: 2, failed: 0, batches: 4, retries: 0,
+  });
+});
+
 test("retries failed batches with a finite budget", async () => {
   let attempts = 0;
   const runtime = {

--- a/sdk/error-tracer.test.js
+++ b/sdk/error-tracer.test.js
@@ -372,6 +372,27 @@ test("capture rejects a non-string JSON serialization result", async () => {
   assert.equal(transports, 0);
 });
 
+test("capture rejects serialized bodies without the expected envelope", async () => {
+  const original = JSON.stringify;
+  const results = [];
+  let transports = 0;
+  try {
+    for (const serialized of ["null", "{}", '{"project_key":"wrong","events":[]}']) {
+      JSON.stringify = () => serialized;
+      results.push(await testClient({
+        transport() {
+          transports++;
+          return true;
+        },
+      }).captureMessage("boom"));
+    }
+  } finally {
+    JSON.stringify = original;
+  }
+  assert.deepEqual(results, [false, false, false]);
+  assert.equal(transports, 0);
+});
+
 test("batch serialization ignores inherited toJSON hooks", async () => {
   const original = Object.prototype.toJSON;
   const bodies = [];

--- a/sdk/error-tracer.test.js
+++ b/sdk/error-tracer.test.js
@@ -146,6 +146,32 @@ test("beforeSend can modify or drop an event", async () => {
   assert.deepEqual(events[0].tags, { filtered: "yes" });
 });
 
+test("beforeSend can remove default context", async () => {
+  let captured;
+  const client = testClient({
+    release: "web@1",
+    environment: "production",
+    tags: { region: "us-east-1" },
+    beforeSend(event) {
+      delete event.page_url;
+      delete event.release;
+      delete event.environment;
+      delete event.tags;
+      return event;
+    },
+    transport(_body, payload) {
+      captured = payload.events[0];
+      return true;
+    },
+  });
+
+  assert.equal(await client.captureMessage("redacted"), true);
+  assert.equal("page_url" in captured, false);
+  assert.equal("release" in captured, false);
+  assert.equal("environment" in captured, false);
+  assert.equal("tags" in captured, false);
+});
+
 test("sampling and the per-minute budget bound traffic", async () => {
   let sent = 0;
   const sampledOut = testClient({
@@ -248,6 +274,41 @@ test("default transport falls back to credential-free fetch", async () => {
   assert.equal(JSON.parse(request.options.body).events[0].message, "boom");
 });
 
+test("default transport disables keepalive for large payloads", async () => {
+  let beaconCalled = false;
+  let request;
+  const runtime = {
+    location: { href: "https://app.example/page" },
+    navigator: {
+      sendBeacon() {
+        beaconCalled = true;
+        return true;
+      },
+    },
+    Blob,
+    fetch(endpoint, options) {
+      request = { endpoint, options };
+      return Promise.resolve({ ok: true });
+    },
+  };
+  const client = ErrorTracer.init({
+    projectKey: PROJECT_KEY,
+    runtime,
+    random: () => 0,
+    clock: () => FIXED_TIME,
+    batchSize: 1,
+    maxBatchBytes: 128 * 1024,
+  });
+
+  assert.equal(await client.capture({
+    kind: "error",
+    message: "boom",
+    stack: "x".repeat(63 * 1024),
+  }), true);
+  assert.equal(beaconCalled, false);
+  assert.equal(request.options.keepalive, false);
+});
+
 test("capture contains extension and transport failures", async () => {
   const badRandom = testClient({
     random() {
@@ -276,6 +337,24 @@ test("capture contains extension and transport failures", async () => {
     },
   });
   assert.equal(await testClient().capture(hostile), false);
+});
+
+test("capture contains JSON serialization failures", async () => {
+  const original = Object.prototype.toJSON;
+  let result;
+  try {
+    Object.prototype.toJSON = function failSerialization() {
+      throw new Error("serialization failed");
+    };
+    result = await testClient().captureMessage("boom");
+  } finally {
+    if (original === undefined) {
+      delete Object.prototype.toJSON;
+    } else {
+      Object.prototype.toJSON = original;
+    }
+  }
+  assert.equal(result, false);
 });
 
 test("automatically captures runtime, resource, and rejection failures", async () => {
@@ -345,6 +424,7 @@ test("automatic capture can be installed and destroyed idempotently", () => {
   assert.equal(runtime.listenerCount("error"), 1);
   assert.equal(runtime.listenerCount("unhandledrejection"), 1);
   assert.equal(runtime.listenerCount("pagehide"), 1);
+  assert.equal(runtime.document.listenerCount("visibilitychange"), 1);
 
   client.destroy();
   client.destroy();
@@ -352,6 +432,33 @@ test("automatic capture can be installed and destroyed idempotently", () => {
   assert.equal(runtime.listenerCount("error"), 0);
   assert.equal(runtime.listenerCount("unhandledrejection"), 0);
   assert.equal(runtime.listenerCount("pagehide"), 0);
+  assert.equal(runtime.document.listenerCount("visibilitychange"), 0);
+});
+
+test("automatic capture rolls back partial listener installation", () => {
+  const listeners = new Map();
+  const runtime = {
+    addEventListener(type, listener) {
+      if (type === "unhandledrejection") {
+        throw new Error("registration failed");
+      }
+      listeners.set(type, listener);
+    },
+    removeEventListener(type, listener) {
+      if (listeners.get(type) === listener) {
+        listeners.delete(type);
+      }
+    },
+  };
+  const client = ErrorTracer.init({
+    projectKey: PROJECT_KEY,
+    runtime,
+    autoCapture: false,
+  });
+
+  assert.equal(client.install(), false);
+  assert.equal(client.installed, false);
+  assert.equal(listeners.size, 0);
 });
 
 test("serializes plain-object rejection reasons", async () => {
@@ -421,6 +528,23 @@ test("splits a queue before the configured request-size limit", async () => {
   assert.deepEqual(payloads.map((payload) => payload.events.length), [1, 1]);
 });
 
+test("drops an event that exceeds maxBatchBytes by itself", async () => {
+  let transportCalled = false;
+  const client = testClient({
+    maxBatchBytes: 1024,
+    transport() {
+      transportCalled = true;
+      return true;
+    },
+  });
+
+  assert.equal(await client.captureMessage("x".repeat(2000)), false);
+  assert.equal(transportCalled, false);
+  assert.deepEqual(client.getStats(), {
+    queued: 0, sent: 0, dropped: 1, failed: 1, batches: 0, retries: 0,
+  });
+});
+
 test("flushes a partial queue after the configured interval", async () => {
   let scheduled;
   const payloads = [];
@@ -485,6 +609,40 @@ test("bounds the queue while another batch is in flight", async () => {
   });
 });
 
+test("flush waits for events queued during an active delivery", async () => {
+  let releaseFirst;
+  let releaseSecond;
+  const deliveries = [
+    new Promise((resolve) => { releaseFirst = resolve; }),
+    new Promise((resolve) => { releaseSecond = resolve; }),
+  ];
+  const messages = [];
+  const client = testClient({
+    transport(_body, payload) {
+      messages.push(payload.events[0].message);
+      return deliveries[messages.length - 1];
+    },
+  });
+
+  const firstCapture = client.captureMessage("one");
+  assert.equal(await client.captureMessage("two"), true);
+  let flushResolved = false;
+  const flush = client.flush().then((accepted) => {
+    flushResolved = true;
+    return accepted;
+  });
+
+  releaseFirst(true);
+  assert.equal(await firstCapture, true);
+  await eventLoopTurn();
+  assert.deepEqual(messages, ["one", "two"]);
+  assert.equal(flushResolved, false);
+
+  releaseSecond(true);
+  assert.equal(await flush, true);
+  assert.equal(flushResolved, true);
+});
+
 test("retries failed batches with a finite budget", async () => {
   let attempts = 0;
   const runtime = {
@@ -534,6 +692,32 @@ test("pagehide flushes a partial queue", async () => {
   assert.equal(payloads[0].events[0].message, "leaving");
 });
 
+test("visibilitychange flushes when the document becomes hidden", async () => {
+  const payloads = [];
+  const runtime = fakeRuntime();
+  const client = testClient({
+    runtime,
+    batchSize: 10,
+    flushInterval: 0,
+    transport(_body, payload) {
+      payloads.push(payload);
+      return true;
+    },
+  });
+
+  assert.equal(await client.captureMessage("backgrounded"), true);
+  runtime.document.visibilityState = "visible";
+  runtime.document.dispatch("visibilitychange", {});
+  await eventLoopTurn();
+  assert.equal(payloads.length, 0);
+
+  runtime.document.visibilityState = "hidden";
+  runtime.document.dispatch("visibilitychange", {});
+  await eventLoopTurn();
+  assert.equal(payloads.length, 1);
+  assert.equal(payloads[0].events[0].message, "backgrounded");
+});
+
 function testClient(overrides) {
   return ErrorTracer.init({
     projectKey: PROJECT_KEY,
@@ -549,9 +733,17 @@ function testClient(overrides) {
 }
 
 function fakeRuntime() {
+  const runtimeTarget = fakeEventTarget();
+  const documentTarget = fakeEventTarget();
+  return Object.assign(runtimeTarget, {
+    location: { href: "https://app.example/page?secret=1#fragment" },
+    document: Object.assign(documentTarget, { visibilityState: "visible" }),
+  });
+}
+
+function fakeEventTarget() {
   const listeners = new Map();
   return {
-    location: { href: "https://app.example/page?secret=1#fragment" },
     addEventListener(type, listener) {
       const registered = listeners.get(type) || new Set();
       registered.add(listener);

--- a/sdk/error-tracer.test.js
+++ b/sdk/error-tracer.test.js
@@ -678,6 +678,40 @@ test("flush waits for events queued during an active delivery", async () => {
   assert.equal(flushResolved, true);
 });
 
+test("flush reserves the events queued when it is called", async () => {
+  let releaseFirst;
+  const payloads = [];
+  const firstDelivery = new Promise((resolve) => {
+    releaseFirst = resolve;
+  });
+  const client = testClient({
+    batchSize: 1,
+    maxQueueSize: 1,
+    flushInterval: 0,
+    transport(_body, payload) {
+      payloads.push(payload);
+      return payloads.length === 1 ? firstDelivery : true;
+    },
+  });
+
+  const firstCapture = client.captureMessage("one");
+  assert.equal(await client.captureMessage("two"), true);
+  const flush = client.flush();
+  assert.equal(await client.captureMessage("three"), true);
+  assert.equal(client.getStats().dropped, 0);
+
+  releaseFirst(true);
+  assert.equal(await firstCapture, true);
+  assert.equal(await flush, true);
+  await eventLoopTurn();
+  assert.equal(await client.flush(), true);
+  assert.deepEqual(
+    payloads.flatMap((payload) => payload.events.map((event) => event.message)),
+    ["one", "two", "three"],
+  );
+  assert.equal(client.getStats().dropped, 0);
+});
+
 test("retries failed batches with a finite budget", async () => {
   let attempts = 0;
   const runtime = {

--- a/sdk/error-tracer.test.js
+++ b/sdk/error-tracer.test.js
@@ -340,31 +340,25 @@ test("capture contains extension and transport failures", async () => {
 });
 
 test("capture contains JSON serialization failures", async () => {
-  const original = Object.prototype.toJSON;
+  const original = JSON.stringify;
   let result;
   try {
-    Object.prototype.toJSON = function failSerialization() {
+    JSON.stringify = function failSerialization() {
       throw new Error("serialization failed");
     };
     result = await testClient().captureMessage("boom");
   } finally {
-    if (original === undefined) {
-      delete Object.prototype.toJSON;
-    } else {
-      Object.prototype.toJSON = original;
-    }
+    JSON.stringify = original;
   }
   assert.equal(result, false);
 });
 
 test("capture rejects a non-string JSON serialization result", async () => {
-  const original = Object.prototype.toJSON;
+  const original = JSON.stringify;
   let result;
   let transports = 0;
   try {
-    Object.prototype.toJSON = function omitSerialization() {
-      return undefined;
-    };
+    JSON.stringify = () => undefined;
     result = await testClient({
       transport() {
         transports++;
@@ -372,14 +366,45 @@ test("capture rejects a non-string JSON serialization result", async () => {
       },
     }).captureMessage("boom");
   } finally {
+    JSON.stringify = original;
+  }
+  assert.equal(result, false);
+  assert.equal(transports, 0);
+});
+
+test("batch serialization ignores inherited toJSON hooks", async () => {
+  const original = Object.prototype.toJSON;
+  const bodies = [];
+  try {
+    for (const replacement of [
+      () => null,
+      () => ({}),
+      () => { throw new Error("inherited hook must not run"); },
+    ]) {
+      Object.prototype.toJSON = replacement;
+      const client = testClient({
+        batchSize: 1,
+        transport(body) {
+          bodies.push(body);
+          return true;
+        },
+      });
+      assert.equal(await client.captureMessage("boom"), true);
+    }
+  } finally {
     if (original === undefined) {
       delete Object.prototype.toJSON;
     } else {
       Object.prototype.toJSON = original;
     }
   }
-  assert.equal(result, false);
-  assert.equal(transports, 0);
+  assert.equal(bodies.length, 3);
+  for (const body of bodies) {
+    const payload = JSON.parse(body);
+    assert.equal(payload.project_key, PROJECT_KEY);
+    assert.equal(payload.events.length, 1);
+    assert.equal(payload.events[0].message, "boom");
+  }
 });
 
 test("automatically captures runtime, resource, and rejection failures", async () => {


### PR DESCRIPTION
## Summary

- keep unload-time payloads within a portable 60 KiB budget and fall back to non-keepalive fetch for larger configured batches
- serialize a null-prototype copy of the batch envelope/events/tags, mask inherited array `toJSON`, and validate the decoded result against the requested envelope
- reject individually oversized, invalid, or non-string JSON results before enqueueing, while retrying transient grouping-time serialization failures
- make every explicit `flush()` immediately reserve the events queued at call time, then serialize that snapshot behind any active delivery
- include waiting snapshots and every not-yet-sent sub-batch—including an initial size-split flush—in `maxQueueSize` and `getStats().queued`, releasing each reservation only as that sub-batch enters transport
- consume the per-minute event budget only after the bounded queue accepts an event
- flush on hidden `visibilitychange`, roll back partial listener installation, and preserve fields intentionally removed by `beforeSend`

## Verification

- `bun test sdk/*.test.js` (33 tests)
- `go test ./...`
- `go vet ./...`
- `bun scripts/check-doc-links.mjs` (10 Markdown files)
- `git diff --check`

Addresses the SDK reliability findings from PRs #16 and #49 and all review threads on this PR.