### PR TITLE
fix: strengthen SQLite startup consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ history rows in the same transaction that records new events.
 | `ERROR_TRACER_ADDRESS` | No | `:8080` | HTTP listen address |
 | `ERROR_TRACER_DATABASE_PATH` | No | `error-tracer.db` | SQLite database path |
 | `ERROR_TRACER_SQLITE_MAX_OPEN_CONNECTIONS` | No | `4` | SQLite pool size, from 1 to 32 |
-| `ERROR_TRACER_MAX_EVENTS_PER_ISSUE` | No | `100` | Newest event rows retained per issue, from 1 to 1,000 |
+| `ERROR_TRACER_MAX_EVENTS_PER_ISSUE` | No | `100` | Newest event rows retained per issue, from 1 to 1,000; lowering it trims existing history at startup |
 | `ERROR_TRACER_PROJECT_ID` | No | `default` | Project namespace owned by this process |
 | `ERROR_TRACER_INGEST_KEY` | Yes | — | Ingestion credential, at least 16 bytes |
 | `ERROR_TRACER_ADMIN_TOKEN` | Yes | — | Admin credential, at least 24 bytes |
@@ -317,18 +317,22 @@ rollback-journal behavior; in-memory databases require that setting. WAL creates
 copying database files. Keep the database on a local filesystem with reliable
 locking rather than a network filesystem that cannot safely support WAL.
 
-The service records an ordered SQLite schema version and applies each pending
-migration in its own transaction at startup. Existing unversioned databases are
-adopted without discarding their issue rows. Back up the database before running
-a newer Error-Tracer release; a build refuses to open a database whose schema is
-newer than it supports.
+The service records an ordered SQLite schema version. At startup, an immediate
+write transaction serializes the version check and every pending migration, so
+concurrent processes cannot apply the same DDL. Existing unversioned databases
+are adopted without discarding their issue rows. Back up the database before
+running a newer Error-Tracer release; a build refuses to open a database whose
+schema is newer than it supports.
 
 Upgrading an existing aggregate-only database creates an empty occurrence
 history. New events are retained after the upgrade; past events cannot be
-reconstructed from the aggregate row.
+reconstructed from the aggregate row. Startup also reconciles every existing
+history with `ERROR_TRACER_MAX_EVENTS_PER_ISSUE`; trimming retained payloads does
+not change the issue's lifetime occurrence count.
 
-The readiness endpoint performs a bounded live read and returns `503` when the
-store is unavailable. The Prometheus output reports both the combined
+The readiness endpoint performs a bounded live read of SQLite's required schema
+and returns `503` when the store or an operational table is unavailable. The
+Prometheus output reports both the combined
 `error_tracer_ready` state and the latest `error_tracer_store_ready` result.
 Use the built-in maintenance commands for a full quick integrity check or a
 consistent online snapshot:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -239,7 +239,7 @@ Authorization: Bearer 替换为管理员令牌
 | `ERROR_TRACER_ADDRESS` | 否 | `:8080` | HTTP 监听地址 |
 | `ERROR_TRACER_DATABASE_PATH` | 否 | `error-tracer.db` | SQLite 数据库路径 |
 | `ERROR_TRACER_SQLITE_MAX_OPEN_CONNECTIONS` | 否 | `4` | SQLite 连接池大小，范围 1–32 |
-| `ERROR_TRACER_MAX_EVENTS_PER_ISSUE` | 否 | `100` | 每问题保留的最新事件数，范围 1–1,000 |
+| `ERROR_TRACER_MAX_EVENTS_PER_ISSUE` | 否 | `100` | 每问题保留的最新事件数，范围 1–1,000；调低后会在启动时裁剪既有历史 |
 | `ERROR_TRACER_PROJECT_ID` | 否 | `default` | 当前进程拥有的项目命名空间 |
 | `ERROR_TRACER_INGEST_KEY` | 是 | — | 采集凭据，至少 16 字节 |
 | `ERROR_TRACER_ADMIN_TOKEN` | 是 | — | 管理凭据，至少 24 字节 |
@@ -270,14 +270,17 @@ Authorization: Bearer 替换为管理员令牌
 理解 SQLite 的备份工具，或停服后再复制数据库文件。数据库应放在锁语义可靠的本地
 文件系统，而不是无法安全支持 WAL 的网络文件系统。
 
-服务会记录有序的 SQLite 架构版本，并在启动时以独立事务应用每一项待执行迁移。
-现有未记录版本的数据库会被接管，已有问题数据不会丢失。运行新版 Error-Tracer
-前应先备份数据库；如果数据库架构版本高于当前程序支持的版本，程序会拒绝启动。
+服务会记录有序的 SQLite 架构版本。启动时会使用即时写事务串行执行版本检查和
+所有待执行迁移，避免并发进程重复应用同一项 DDL。现有未记录版本的数据库会被
+接管，已有问题数据不会丢失。运行新版 Error-Tracer 前应先备份数据库；如果数据库
+架构版本高于当前程序支持的版本，程序会拒绝启动。
 
 从只保存聚合数据的旧数据库升级时，事件历史初始为空；升级后的新事件会被保留，
-但无法从聚合行还原升级前的每次事件。
+但无法从聚合行还原升级前的每次事件。启动时还会按照
+`ERROR_TRACER_MAX_EVENTS_PER_ISSUE` 裁剪所有既有历史；删除已保留的载荷不会改变
+问题的累计发生次数。
 
-就绪接口会执行有超时边界的实时读取；存储不可用时返回 `503`。Prometheus 输出
+就绪接口会实时读取 SQLite 所需架构；存储或必需表不可用时返回 `503`。Prometheus 输出
 同时提供综合状态 `error_tracer_ready` 和最近一次存储探测结果
 `error_tracer_store_ready`。可使用内置维护命令执行完整的快速一致性检查或创建
 在线一致快照：

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -110,6 +110,11 @@ WHERE sequence IN (
 )
 `
 
+const (
+	sqliteHistoryReconcileGroupBatch = 100
+	sqliteIssueCursorPredicate       = " AND last_seen <= ? AND (last_seen < ? OR (last_seen = ? AND fingerprint > ?))"
+)
+
 var (
 	ErrDatabasePathRequired = errors.New("database path is required")
 	ErrBackupPathRequired   = errors.New("backup path is required")
@@ -213,13 +218,31 @@ func OpenSQLiteWithOptions(ctx context.Context, path string, options SQLiteOptio
 	if err := migrateSQLite(ctx, database, sqliteMigrations); err != nil {
 		return fail("migrate sqlite database", err)
 	}
+	if err := reconcileSQLiteEventHistory(ctx, database, maxEvents); err != nil {
+		return fail("reconcile sqlite event history", err)
+	}
 
 	return &SQLite{db: database, maxEventsPerIssue: maxEvents}, nil
 }
 
 func migrateSQLite(ctx context.Context, database *sql.DB, migrations []sqliteMigration) error {
+	connection, err := database.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire migration connection: %w", err)
+	}
+	defer connection.Close()
+	if _, err := connection.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return fmt.Errorf("begin immediate migration transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = connection.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
+
 	var currentVersion int
-	if err := database.QueryRowContext(ctx, "PRAGMA user_version").Scan(&currentVersion); err != nil {
+	if err := connection.QueryRowContext(ctx, "PRAGMA user_version").Scan(&currentVersion); err != nil {
 		return fmt.Errorf("read schema version: %w", err)
 	}
 	latestVersion := 0
@@ -240,26 +263,92 @@ func migrateSQLite(ctx context.Context, database *sql.DB, migrations []sqliteMig
 				currentVersion, migration.version,
 			)
 		}
-		transaction, err := database.BeginTx(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("begin migration %d (%s): %w", migration.version, migration.name, err)
-		}
-		if _, err := transaction.ExecContext(ctx, migration.schema); err != nil {
-			_ = transaction.Rollback()
+		if _, err := connection.ExecContext(ctx, migration.schema); err != nil {
 			return fmt.Errorf("apply migration %d (%s): %w", migration.version, migration.name, err)
 		}
-		if _, err := transaction.ExecContext(
+		if _, err := connection.ExecContext(
 			ctx, fmt.Sprintf("PRAGMA user_version = %d", migration.version),
 		); err != nil {
-			_ = transaction.Rollback()
 			return fmt.Errorf("record migration %d (%s): %w", migration.version, migration.name, err)
-		}
-		if err := transaction.Commit(); err != nil {
-			return fmt.Errorf("commit migration %d (%s): %w", migration.version, migration.name, err)
 		}
 		currentVersion = migration.version
 	}
+	if _, err := connection.ExecContext(ctx, "COMMIT"); err != nil {
+		return fmt.Errorf("commit SQLite migrations: %w", err)
+	}
+	committed = true
 	return nil
+}
+
+func reconcileSQLiteEventHistory(ctx context.Context, database *sql.DB, maximum int) error {
+	var afterProject, afterFingerprint string
+	hasCursor := false
+	for {
+		whereClause := ""
+		arguments := make([]any, 0, 4)
+		if hasCursor {
+			whereClause = "WHERE (project_id, fingerprint) > (?, ?)"
+			arguments = append(arguments, afterProject, afterFingerprint)
+		}
+		arguments = append(arguments, maximum, sqliteHistoryReconcileGroupBatch)
+		rows, err := database.QueryContext(ctx, `
+SELECT project_id, fingerprint
+FROM events
+`+whereClause+`
+GROUP BY project_id, fingerprint
+HAVING COUNT(*) > ?
+ORDER BY project_id ASC, fingerprint ASC
+LIMIT ?
+`, arguments...)
+		if err != nil {
+			return fmt.Errorf("find oversized event histories: %w", err)
+		}
+		type issueKey struct {
+			projectID   string
+			fingerprint string
+		}
+		groups := make([]issueKey, 0, sqliteHistoryReconcileGroupBatch)
+		for rows.Next() {
+			var group issueKey
+			if err := rows.Scan(&group.projectID, &group.fingerprint); err != nil {
+				_ = rows.Close()
+				return fmt.Errorf("scan oversized event history: %w", err)
+			}
+			groups = append(groups, group)
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("iterate oversized event histories: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			return fmt.Errorf("close oversized event histories: %w", err)
+		}
+		if len(groups) == 0 {
+			return nil
+		}
+
+		transaction, err := database.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin event history reconciliation: %w", err)
+		}
+		for _, group := range groups {
+			if _, err := transaction.ExecContext(
+				ctx, sqliteTrimEvents, group.projectID, group.fingerprint, maximum,
+			); err != nil {
+				_ = transaction.Rollback()
+				return fmt.Errorf(
+					"trim event history for %s/%s: %w",
+					group.projectID, group.fingerprint, err,
+				)
+			}
+		}
+		if err := transaction.Commit(); err != nil {
+			return fmt.Errorf("commit event history reconciliation: %w", err)
+		}
+		last := groups[len(groups)-1]
+		afterProject, afterFingerprint = last.projectID, last.fingerprint
+		hasCursor = true
+	}
 }
 
 func sqliteDataSourceName(path string, connections int) string {
@@ -315,17 +404,21 @@ func (s *SQLite) Close() error {
 	return s.db.Close()
 }
 
-// Ready verifies that the connection pool can execute a lightweight read.
+// Ready verifies that the connection pool can read the required schema.
 func (s *SQLite) Ready(ctx context.Context) error {
 	if s == nil || s.db == nil {
 		return errors.New("SQLite database is unavailable")
 	}
-	var value int
-	if err := s.db.QueryRowContext(ctx, "SELECT 1").Scan(&value); err != nil {
+	var tables int
+	if err := s.db.QueryRowContext(ctx, `
+SELECT COUNT(*)
+FROM sqlite_schema
+WHERE type = 'table' AND name IN ('issues', 'events')
+`).Scan(&tables); err != nil {
 		return fmt.Errorf("probe sqlite database: %w", err)
 	}
-	if value != 1 {
-		return fmt.Errorf("probe sqlite database: returned %d, want 1", value)
+	if tables != 2 {
+		return fmt.Errorf("probe sqlite database: found %d of 2 required tables", tables)
 	}
 	return nil
 }
@@ -572,10 +665,10 @@ func (s *SQLite) ListIssues(ctx context.Context, projectID string, options ListO
 		return IssuePage{}, fmt.Errorf("count issues: %w", err)
 	}
 	if options.After != nil {
-		whereClause += " AND (last_seen < ? OR (last_seen = ? AND fingerprint > ?))"
+		whereClause += sqliteIssueCursorPredicate
 		lastSeen := options.After.LastSeen.UnixNano()
 		queryArguments = append(
-			queryArguments, lastSeen, lastSeen, options.After.Fingerprint,
+			queryArguments, lastSeen, lastSeen, lastSeen, options.After.Fingerprint,
 		)
 	}
 

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -157,6 +157,75 @@ func TestSQLiteMigrationRollsBackFailedVersion(t *testing.T) {
 	}
 }
 
+func TestSQLiteMigrationsLockBeforeReadingTheSchemaVersion(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "migration-lock.db")
+	dataSourceName := sqliteDataSourceName(path, 1)
+	blocker, err := sql.Open("sqlite", dataSourceName)
+	if err != nil {
+		t.Fatalf("open migration blocker: %v", err)
+	}
+	t.Cleanup(func() { _ = blocker.Close() })
+	blocker.SetMaxOpenConns(1)
+	blocker.SetMaxIdleConns(1)
+	blockerConnection, err := blocker.Conn(ctx)
+	if err != nil {
+		t.Fatalf("acquire migration blocker: %v", err)
+	}
+	t.Cleanup(func() { _ = blockerConnection.Close() })
+	if _, err := blockerConnection.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		t.Fatalf("begin blocking transaction: %v", err)
+	}
+	released := false
+	t.Cleanup(func() {
+		if !released {
+			_, _ = blockerConnection.ExecContext(context.Background(), "ROLLBACK")
+		}
+	})
+
+	databases := make([]*sql.DB, 2)
+	for index := range databases {
+		databases[index], err = sql.Open("sqlite", dataSourceName)
+		if err != nil {
+			t.Fatalf("open migration database %d: %v", index, err)
+		}
+		databases[index].SetMaxOpenConns(1)
+		databases[index].SetMaxIdleConns(1)
+		t.Cleanup(func() { _ = databases[index].Close() })
+	}
+	migrations := []sqliteMigration{{
+		version: 1,
+		name:    "serialized migration",
+		schema:  "CREATE TABLE migration_lock_test (id INTEGER)",
+	}}
+	errorsChannel := make(chan error, len(databases))
+	for _, database := range databases {
+		go func() {
+			errorsChannel <- migrateSQLite(ctx, database, migrations)
+		}()
+	}
+	for index, database := range databases {
+		waitForSQLiteConnectionUse(t, database, fmt.Sprintf("migration database %d", index))
+	}
+	if _, err := blockerConnection.ExecContext(ctx, "COMMIT"); err != nil {
+		t.Fatalf("release migration blocker: %v", err)
+	}
+	released = true
+	for range databases {
+		if err := <-errorsChannel; err != nil {
+			t.Fatalf("concurrent migration: %v", err)
+		}
+	}
+
+	var version int
+	if err := databases[0].QueryRowContext(ctx, "PRAGMA user_version").Scan(&version); err != nil {
+		t.Fatalf("read serialized migration version: %v", err)
+	}
+	if version != 1 {
+		t.Fatalf("serialized migration version = %d, want 1", version)
+	}
+}
+
 func TestSQLiteRecordBatchUsesOneAtomicTransaction(t *testing.T) {
 	database := openTestSQLite(t, ":memory:")
 	t.Cleanup(func() { _ = database.Close() })
@@ -322,6 +391,65 @@ func TestSQLiteListIssuesCursorHandlesEqualTimestamps(t *testing.T) {
 	}
 }
 
+func TestSQLiteIssueCursorAddsAnIndexedLastSeenRange(t *testing.T) {
+	database := openTestSQLite(t, ":memory:")
+	t.Cleanup(func() { _ = database.Close() })
+	lastSeen := time.Now().UTC().UnixNano()
+	tests := []struct {
+		name      string
+		where     string
+		arguments []any
+		index     string
+	}{
+		{
+			name:      "all statuses",
+			where:     "project_id = ?" + sqliteIssueCursorPredicate,
+			arguments: []any{"project-a", lastSeen, lastSeen, lastSeen, "fingerprint"},
+			index:     "issues_project_last_seen_fingerprint",
+		},
+		{
+			name:      "one status",
+			where:     "project_id = ? AND status = ?" + sqliteIssueCursorPredicate,
+			arguments: []any{"project-a", IssueStatusOpen, lastSeen, lastSeen, lastSeen, "fingerprint"},
+			index:     "issues_project_status_last_seen_fingerprint",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			arguments := append(append([]any{}, test.arguments...), 26, 0)
+			rows, err := database.db.QueryContext(context.Background(), `
+EXPLAIN QUERY PLAN
+SELECT project_id, fingerprint
+FROM issues
+WHERE `+test.where+`
+ORDER BY last_seen DESC, fingerprint ASC
+LIMIT ? OFFSET ?
+`, arguments...)
+			if err != nil {
+				t.Fatalf("explain cursor query: %v", err)
+			}
+			defer rows.Close()
+			var details []string
+			for rows.Next() {
+				var id, parent, unused int
+				var detail string
+				if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+					t.Fatalf("scan cursor query plan: %v", err)
+				}
+				details = append(details, detail)
+			}
+			if err := rows.Err(); err != nil {
+				t.Fatalf("iterate cursor query plan: %v", err)
+			}
+			plan := strings.ToLower(strings.Join(details, "\n"))
+			if !strings.Contains(plan, strings.ToLower(test.index)) ||
+				!strings.Contains(plan, "last_seen<?") {
+				t.Fatalf("cursor query plan does not use the composite range index:\n%s", plan)
+			}
+		})
+	}
+}
+
 func TestSQLiteListIssuesFiltersByStatus(t *testing.T) {
 	database := openTestSQLite(t, ":memory:")
 	t.Cleanup(func() { _ = database.Close() })
@@ -416,6 +544,76 @@ func TestSQLiteListIssueEventsIsBoundedProjectScopedAndCursorPaginated(t *testin
 		context.Background(), "project-a", "missing", EventListOptions{},
 	); !errors.Is(err, ErrIssueNotFound) {
 		t.Fatalf("missing issue history error = %v, want ErrIssueNotFound", err)
+	}
+}
+
+func TestSQLiteOpenReconcilesALowerEventHistoryLimit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "history-limit.db")
+	database, err := OpenSQLiteWithOptions(
+		context.Background(), path,
+		SQLiteOptions{MaxOpenConnections: 1, MaxEventsPerIssue: 3},
+	)
+	if err != nil {
+		t.Fatalf("open SQLite with initial history limit: %v", err)
+	}
+	groupCount := sqliteHistoryReconcileGroupBatch + 1
+	captured := make([]event.Event, 0, groupCount*3)
+	base := time.Date(2026, time.August, 30, 1, 0, 0, 0, time.UTC)
+	for group := range groupCount {
+		for occurrence := range 3 {
+			item := testEvent(base.Add(time.Duration(occurrence) * time.Minute))
+			item.ID = fmt.Sprintf("history-%03d-%d", group, occurrence)
+			item.Message = fmt.Sprintf("history group %03d", group)
+			captured = append(captured, item)
+		}
+	}
+	if _, err := database.RecordBatch(context.Background(), "project-a", captured); err != nil {
+		t.Fatalf("seed event histories: %v", err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatalf("close SQLite with initial history limit: %v", err)
+	}
+
+	database, err = OpenSQLiteWithOptions(
+		context.Background(), path,
+		SQLiteOptions{MaxOpenConnections: 1, MaxEventsPerIssue: 2},
+	)
+	if err != nil {
+		t.Fatalf("reopen SQLite with lower history limit: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	var oversized, retained int
+	if err := database.db.QueryRow(`
+SELECT COUNT(*)
+FROM (
+    SELECT 1
+    FROM events
+    GROUP BY project_id, fingerprint
+    HAVING COUNT(*) > 2
+)
+`).Scan(&oversized); err != nil {
+		t.Fatalf("count oversized histories: %v", err)
+	}
+	if err := database.db.QueryRow("SELECT COUNT(*) FROM events").Scan(&retained); err != nil {
+		t.Fatalf("count retained event history: %v", err)
+	}
+	if oversized != 0 || retained != groupCount*2 {
+		t.Fatalf(
+			"oversized histories = %d, retained events = %d, want 0 and %d",
+			oversized, retained, groupCount*2,
+		)
+	}
+	var minimumOccurrences, maximumOccurrences int
+	if err := database.db.QueryRow(
+		"SELECT MIN(occurrences), MAX(occurrences) FROM issues",
+	).Scan(&minimumOccurrences, &maximumOccurrences); err != nil {
+		t.Fatalf("read lifetime occurrence counts: %v", err)
+	}
+	if minimumOccurrences != 3 || maximumOccurrences != 3 {
+		t.Fatalf(
+			"lifetime occurrences range = %d..%d, want 3..3",
+			minimumOccurrences, maximumOccurrences,
+		)
 	}
 }
 
@@ -736,6 +934,35 @@ func TestSQLitePruneIssuesBoundsEachDelete(t *testing.T) {
 	}
 }
 
+func TestSQLiteReadyRequiresTheOperationalSchema(t *testing.T) {
+	database, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open schema probe database: %v", err)
+	}
+	database.SetMaxOpenConns(1)
+	database.SetMaxIdleConns(1)
+	t.Cleanup(func() { _ = database.Close() })
+	if _, err := database.Exec(sqliteInitialSchema); err != nil {
+		t.Fatalf("create partial schema: %v", err)
+	}
+	store := &SQLite{db: database}
+	if err := store.Ready(context.Background()); err == nil {
+		t.Fatal("Ready() error = nil with the events table missing")
+	}
+	if _, err := database.Exec(sqliteEventHistorySchema); err != nil {
+		t.Fatalf("complete operational schema: %v", err)
+	}
+	if err := store.Ready(context.Background()); err != nil {
+		t.Fatalf("Ready() with the complete schema: %v", err)
+	}
+	if _, err := database.Exec("DROP TABLE events"); err != nil {
+		t.Fatalf("drop required events table: %v", err)
+	}
+	if err := store.Ready(context.Background()); err == nil {
+		t.Fatal("Ready() error = nil after a required table was removed")
+	}
+}
+
 func TestSQLiteReadOnlyMaintenanceAndAtomicBackup(t *testing.T) {
 	directory := t.TempDir()
 	sourcePath := filepath.Join(directory, "source #1.db")
@@ -793,4 +1020,28 @@ func openTestSQLite(t *testing.T, path string) *SQLite {
 		t.Fatalf("open SQLite database: %v", err)
 	}
 	return database
+}
+
+func waitForSQLiteConnectionUse(t *testing.T, database *sql.DB, description string) {
+	t.Helper()
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	consecutive := 0
+	for {
+		if database.Stats().InUse > 0 {
+			consecutive++
+			if consecutive >= 10 {
+				return
+			}
+		} else {
+			consecutive = 0
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("timed out waiting for %s to reach the migration lock", description)
+		case <-ticker.C:
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- add an explicit `last_seen <= cursor` range so issue cursor scans can seek through the composite indexes
- acquire `BEGIN IMMEDIATE` before reading `user_version`, serializing the version check and pending DDL across concurrent starters
- reconcile pre-existing event histories in bounded issue groups whenever `MAX_EVENTS_PER_ISSUE` is lowered, without changing lifetime occurrence counts
- make readiness query SQLite's required operational tables rather than evaluate a constant expression
- update the English and Chinese operational documentation

## Verification

- `go test ./...`
- `go test -race ./...`
- targeted migration/history/cursor/readiness regressions repeated 20 times
- migration locking regression repeated 50 times
- `BenchmarkListIssues/.../Cursor_475` smoke benchmark
- `git diff --check`