### PR TITLE
fix: harden reference-style link parsing

### DIFF
--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -52,7 +52,7 @@ export function markdownTargets(contents) {
     const definition = referenceDefinitionAt(lines, index);
     if (definition) {
       targets.push(definition.target);
-      index += definition.continued ? 1 : 0;
+      index += definition.consumed;
     }
   }
   return targets;
@@ -68,7 +68,7 @@ function referenceDefinitionAt(lines, index) {
   }
 
   let remainder = match[2];
-  let continued = false;
+  let consumed = 0;
   if (!remainder.trim()) {
     if (index + 1 >= lines.length) {
       return null;
@@ -87,11 +87,35 @@ function referenceDefinitionAt(lines, index) {
       return null;
     }
     remainder = continuationMatch[1];
-    continued = true;
+    consumed = 1;
   }
 
-  const target = referenceDestination(remainder);
-  return target === null ? null : { target, continued };
+  const destination = referenceDestination(remainder);
+  if (destination === null) {
+    return null;
+  }
+  if (destination.trailing) {
+    const title = completeReferenceTitle(
+      destination.trailing, lines, index + consumed + 1, parsedLine.containers,
+    );
+    if (!title.valid) {
+      return null;
+    }
+    consumed += title.consumed;
+  } else {
+    const nextLine = referenceContinuation(
+      lines, index + consumed + 1, parsedLine.containers,
+    );
+    if (nextLine !== null && /^["'(]/.test(nextLine)) {
+      const title = completeReferenceTitle(
+        nextLine, lines, index + consumed + 2, parsedLine.containers,
+      );
+      if (title.valid) {
+        consumed += title.consumed + 1;
+      }
+    }
+  }
+  return { target: destination.target, consumed };
 }
 
 function referenceDestination(remainder) {
@@ -114,14 +138,53 @@ function referenceDestination(remainder) {
     trailing = match[2].trim();
   }
 
-  if (trailing && !referenceTitle(trailing)) {
-    return null;
-  }
-  return target;
+  return { target, trailing };
 }
 
 function referenceTitle(value) {
   return /^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))$/.test(value);
+}
+
+function completeReferenceTitle(initial, lines, nextIndex, containers) {
+  let value = initial.trim();
+  let consumed = 0;
+  while (true) {
+    if (referenceTitle(value)) {
+      return { valid: true, consumed };
+    }
+    if (!unterminatedReferenceTitle(value)) {
+      return { valid: false, consumed: 0 };
+    }
+    const continuation = referenceContinuation(lines, nextIndex + consumed, containers);
+    if (continuation === null || !continuation.trim()) {
+      return { valid: false, consumed: 0 };
+    }
+    value += `\n${continuation.trimEnd()}`;
+    consumed++;
+  }
+}
+
+function unterminatedReferenceTitle(value) {
+  const closing = value[0] === "(" ? ")" : value[0];
+  if (closing !== ")" && closing !== "\"" && closing !== "'") {
+    return false;
+  }
+  for (let index = 1; index < value.length; index++) {
+    if (value[index] === "\\") {
+      index++;
+    } else if (value[index] === closing) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function referenceContinuation(lines, index, containers) {
+  if (index >= lines.length) {
+    return null;
+  }
+  const continuation = continueBlockContainers(lines[index], containers);
+  return continuation?.match(/^[ \t]{0,3}(\S.*)$/)?.[1] || null;
 }
 
 function parseBlockContainers(line) {

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -214,7 +214,8 @@ function parseBlockContainers(line, orderedListCanInterrupt = null) {
     const list = listMarkerPrefix(remaining);
     if (list) {
       if ((list.empty ||
-           (list.orderedStart !== null && list.orderedStart !== 1)) &&
+           (list.orderedStart !== null && list.orderedStart !== 1) ||
+           stripIndent(remaining.slice(list.length), 4) !== null) &&
           orderedListCanInterrupt && !orderedListCanInterrupt(containers)) {
         return { content: remaining, containers };
       }
@@ -238,6 +239,7 @@ function parseContinuedBlockContainers(
   orderedListCanInterrupt,
 ) {
   const continued = blockContainerPrefix(line, activeContainers);
+  const startsSiblingListItem = startsNewListItem(line, activeContainers);
   let containers = activeContainers.slice(0, continued.count);
   let content = continued.content;
   if (continued.count < activeContainers.length && activeParagraphOpen &&
@@ -254,6 +256,7 @@ function parseContinuedBlockContainers(
   }
 
   const nested = parseBlockContainers(content, (nestedContainers) =>
+    startsSiblingListItem ||
     orderedListCanInterrupt([...containers, ...nestedContainers]));
   return {
     content: nested.content,

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -250,6 +250,7 @@ function parseBlockContainers(line, orderedListCanInterrupt = null) {
       containers.push({
         type: "list",
         indent: list.indent,
+        marker: list.marker,
         markerIndent: list.markerIndent,
         orderedStart: list.orderedStart,
       });
@@ -315,6 +316,7 @@ function listMarkerPrefix(value) {
   if (!marker) {
     return null;
   }
+  const markerText = marker[0].slice(marker[1].length);
 
   let index = marker[0].length;
   const markerColumn = indentationWidth(value.slice(0, index));
@@ -323,6 +325,7 @@ function listMarkerPrefix(value) {
     return {
       length: index,
       indent: markerColumn + 1,
+      marker: markerText,
       markerIndent: marker[1].length,
       orderedStart: marker[2] === undefined ? null : Number(marker[2]),
       empty: true,
@@ -342,6 +345,7 @@ function listMarkerPrefix(value) {
       return {
         length: firstPaddingEnd,
         indent: firstPaddingColumn,
+        marker: markerText,
         markerIndent: marker[1].length,
         orderedStart: marker[2] === undefined ? null : Number(marker[2]),
         empty,
@@ -352,6 +356,7 @@ function listMarkerPrefix(value) {
   return {
     length: index,
     indent: column,
+    marker: markerText,
     markerIndent: marker[1].length,
     orderedStart: marker[2] === undefined ? null : Number(marker[2]),
     empty,
@@ -614,15 +619,16 @@ function withoutFencedCode(contents) {
     if (fence) {
       const content = continueBlockContainers(line, fence.containers);
       if (content !== null) {
+        const containers = fence.containers;
         const closing = content.match(/^ {0,3}(`+|~+)[ \t]*$/)?.[1] || "";
         if (closing[0] === fence.character && closing.length >= fence.length) {
           fence = null;
         }
-        output.push("");
+        output.push(maskedContainerLine(containers));
         continue;
       }
       if (blankWithinBlockContainers(line, fence.containers)) {
-        output.push("");
+        output.push(maskedContainerLine(fence.containers));
         continue;
       }
       fence = null;
@@ -631,14 +637,15 @@ function withoutFencedCode(contents) {
     if (htmlBlock) {
       const content = continueBlockContainers(line, htmlBlock.containers);
       if (content !== null) {
+        const containers = htmlBlock.containers;
         if (htmlBlock.terminator.test(content)) {
           htmlBlock = null;
         }
-        output.push("");
+        output.push(maskedContainerLine(containers));
         continue;
       }
       if (blankWithinBlockContainers(line, htmlBlock.containers)) {
-        output.push("");
+        output.push(maskedContainerLine(htmlBlock.containers));
         continue;
       }
       htmlBlock = null;
@@ -675,7 +682,7 @@ function withoutFencedCode(contents) {
          !paragraphOpenBefore(
            output, output.length, parsed.containers, paragraphCache,
          ))) {
-      output.push("");
+      output.push(maskedContainerLine(parsed.containers));
       continue;
     }
     const openingHTML = htmlBlockAt(parsed.content);
@@ -686,7 +693,7 @@ function withoutFencedCode(contents) {
           containers: parsed.containers,
         };
       }
-      output.push("");
+      output.push(maskedContainerLine(parsed.containers));
       continue;
     }
     const opening = fencedCodeOpening(parsed.content);
@@ -696,12 +703,27 @@ function withoutFencedCode(contents) {
         length: opening.length,
         containers: parsed.containers,
       };
-      output.push("");
+      output.push(maskedContainerLine(parsed.containers));
       continue;
     }
     output.push(line);
   }
   return output.join("\n");
+}
+
+function maskedContainerLine(containers) {
+  let line = "";
+  for (const container of containers) {
+    if (container.type === "quote") {
+      line += "> ";
+      continue;
+    }
+    const padding = container.indent - container.markerIndent -
+      container.marker.length;
+    line += `${" ".repeat(container.markerIndent)}${container.marker}` +
+      " ".repeat(Math.max(1, padding));
+  }
+  return line;
 }
 
 function fencedCodeOpening(content) {

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -507,6 +507,9 @@ function paragraphOpenAfter(line, paragraphOpen, tableHeader = null) {
       /^ {0,3}(?:(?:\*[ \t]*){3,}|(?:_[ \t]*){3,}|(?:-[ \t]*)+|=+[ \t]*)$/.test(value)) {
     return false;
   }
+  if (/^ {0,3}\[\^(?:\\.|[^\]\\\n])+\]:/.test(value)) {
+    return false;
+  }
   if (/^ {0,3}\[(?!\^)(?:\\.|[^\]\\\n])+\]:/.test(value)) {
     return paragraphOpen;
   }

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -48,8 +48,9 @@ export function markdownTargets(contents) {
     targets.push(match[1].replace(/^<|>$/g, ""));
   }
   const lines = markdown.split("\n");
+  const paragraphCache = new Map();
   for (let index = 0; index < lines.length; index++) {
-    const definition = referenceDefinitionAt(lines, index);
+    const definition = referenceDefinitionAt(lines, index, true, paragraphCache);
     if (definition) {
       targets.push(definition.target);
       index += definition.consumed;
@@ -58,17 +59,25 @@ export function markdownTargets(contents) {
   return targets;
 }
 
-function referenceDefinitionAt(lines, index, checkParagraphInterruption = true) {
+function referenceDefinitionAt(
+  lines,
+  index,
+  checkParagraphInterruption = true,
+  paragraphCache = null,
+) {
   const parsedLine = parseBlockContainers(lines[index]);
-  if (checkParagraphInterruption &&
-      (orderedListInterruptsParagraph(lines, index, parsedLine.containers) ||
-       paragraphOpenBefore(lines, index, parsedLine.containers))) {
-    return null;
-  }
   const match = parsedLine.content.match(
     /^[ \t]{0,3}\[(?!\^)((?:\\.|[^\]\\\n])+)\]:[ \t]*(.*)$/,
   );
   if (!match) {
+    return null;
+  }
+  if (checkParagraphInterruption &&
+      (orderedListInterruptsParagraph(
+        lines, index, parsedLine.containers, paragraphCache,
+      ) || paragraphOpenBefore(
+        lines, index, parsedLine.containers, paragraphCache,
+      ))) {
     return null;
   }
 
@@ -242,7 +251,7 @@ function listMarkerPrefix(value) {
   };
 }
 
-function orderedListInterruptsParagraph(lines, index, containers) {
+function orderedListInterruptsParagraph(lines, index, containers, paragraphCache) {
   const listIndex = containers.findIndex((container) =>
     container.type === "list" &&
     container.orderedStart !== null &&
@@ -250,29 +259,41 @@ function orderedListInterruptsParagraph(lines, index, containers) {
   if (listIndex < 0) {
     return false;
   }
-  return paragraphOpenBefore(lines, index, containers.slice(0, listIndex));
+  return paragraphOpenBefore(
+    lines, index, containers.slice(0, listIndex), paragraphCache,
+  );
 }
 
-function paragraphOpenBefore(lines, index, containers) {
-  let paragraphOpen = false;
-  for (let previous = 0; previous < index; previous++) {
+function paragraphOpenBefore(lines, index, containers, paragraphCache) {
+  const cache = paragraphCache || new Map();
+  const key = containers.map((container) => container.type === "quote"
+    ? "quote"
+    : `list:${container.indent}:${container.orderedStart ?? "bullet"}`).join("/");
+  let state = cache.get(key);
+  if (!state || state.index > index) {
+    state = { index: 0, paragraphOpen: false };
+    cache.set(key, state);
+  }
+  while (state.index < index) {
+    const previous = state.index;
+    state.index++;
     const content = continueBlockContainers(lines[previous], containers);
     if (content === null) {
-      paragraphOpen = false;
+      state.paragraphOpen = false;
       continue;
     }
-    const nextParagraphOpen = paragraphOpenAfter(content, paragraphOpen);
-    if (!paragraphOpen || !nextParagraphOpen) {
+    const nextParagraphOpen = paragraphOpenAfter(content, state.paragraphOpen);
+    if (!state.paragraphOpen || !nextParagraphOpen) {
       const definition = referenceDefinitionAt(lines, previous, false);
       if (definition) {
-        paragraphOpen = false;
-        previous += definition.consumed;
+        state.paragraphOpen = false;
+        state.index += definition.consumed;
         continue;
       }
     }
-    paragraphOpen = nextParagraphOpen;
+    state.paragraphOpen = nextParagraphOpen;
   }
-  return paragraphOpen;
+  return state.paragraphOpen;
 }
 
 function paragraphOpenAfter(line, paragraphOpen) {
@@ -370,6 +391,7 @@ function isExternal(target) {
 
 function withoutFencedCode(contents) {
   let fence = null;
+  let htmlBlock = null;
   return contents.split("\n").map((line) => {
     if (fence) {
       const content = continueBlockContainers(line, fence.containers);
@@ -386,7 +408,31 @@ function withoutFencedCode(contents) {
       fence = null;
     }
 
+    if (htmlBlock) {
+      const content = continueBlockContainers(line, htmlBlock.containers);
+      if (content !== null) {
+        if (htmlBlock.terminator.test(content)) {
+          htmlBlock = null;
+        }
+        return "";
+      }
+      if (blankWithinBlockContainers(line, htmlBlock.containers)) {
+        return "";
+      }
+      htmlBlock = null;
+    }
+
     const parsed = parseBlockContainers(line);
+    const openingHTML = htmlBlockAt(parsed.content);
+    if (openingHTML) {
+      if (!openingHTML.terminator.test(parsed.content)) {
+        htmlBlock = {
+          terminator: openingHTML.terminator,
+          containers: parsed.containers,
+        };
+      }
+      return "";
+    }
     const opening = parsed.content.match(/^[ \t]{0,3}(`{3,}|~{3,})(.*)$/);
     if (opening && !(opening[1][0] === "`" && opening[2].includes("`"))) {
       fence = {
@@ -398,6 +444,26 @@ function withoutFencedCode(contents) {
     }
     return line;
   }).join("\n");
+}
+
+function htmlBlockAt(content) {
+  const typeOne = content.match(/^ {0,3}<(script|pre|style|textarea)(?:[ \t]|>|$)/i);
+  if (typeOne) {
+    return { terminator: new RegExp(`</${typeOne[1]}[ \\t]*>`, "i") };
+  }
+  if (/^ {0,3}<!--/.test(content)) {
+    return { terminator: /-->/ };
+  }
+  if (/^ {0,3}<\?/.test(content)) {
+    return { terminator: /\?>/ };
+  }
+  if (/^ {0,3}<!\[CDATA\[/.test(content)) {
+    return { terminator: /\]\]>/ };
+  }
+  if (/^ {0,3}<![A-Z]/.test(content)) {
+    return { terminator: />/ };
+  }
+  return null;
 }
 
 function run() {

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -201,7 +201,7 @@ function referenceContinuation(lines, index, containers) {
   return continuation?.match(/^[ \t]{0,3}(\S.*)$/)?.[1] || null;
 }
 
-function parseBlockContainers(line) {
+function parseBlockContainers(line, orderedListCanInterrupt = null) {
   let remaining = line.replace(/\r$/, "");
   const containers = [];
   while (true) {
@@ -213,6 +213,10 @@ function parseBlockContainers(line) {
     }
     const list = listMarkerPrefix(remaining);
     if (list) {
+      if (list.orderedStart !== null && list.orderedStart !== 1 &&
+          orderedListCanInterrupt && !orderedListCanInterrupt(containers)) {
+        return { content: remaining, containers };
+      }
       remaining = remaining.slice(list.length);
       containers.push({
         type: "list",
@@ -392,7 +396,9 @@ function isExternal(target) {
 function withoutFencedCode(contents) {
   let fence = null;
   let htmlBlock = null;
-  return contents.split("\n").map((line) => {
+  const output = [];
+  const paragraphCache = new Map();
+  for (const line of contents.split("\n")) {
     if (fence) {
       const content = continueBlockContainers(line, fence.containers);
       if (content !== null) {
@@ -400,10 +406,12 @@ function withoutFencedCode(contents) {
         if (closing[0] === fence.character && closing.length >= fence.length) {
           fence = null;
         }
-        return "";
+        output.push("");
+        continue;
       }
       if (blankWithinBlockContainers(line, fence.containers)) {
-        return "";
+        output.push("");
+        continue;
       }
       fence = null;
     }
@@ -414,15 +422,20 @@ function withoutFencedCode(contents) {
         if (htmlBlock.terminator.test(content)) {
           htmlBlock = null;
         }
-        return "";
+        output.push("");
+        continue;
       }
       if (blankWithinBlockContainers(line, htmlBlock.containers)) {
-        return "";
+        output.push("");
+        continue;
       }
       htmlBlock = null;
     }
 
-    const parsed = parseBlockContainers(line);
+    const parsed = parseBlockContainers(line, (containers) =>
+      !paragraphOpenBefore(
+        output, output.length, containers, paragraphCache,
+      ));
     const openingHTML = htmlBlockAt(parsed.content);
     if (openingHTML) {
       if (!openingHTML.terminator.test(parsed.content)) {
@@ -431,7 +444,8 @@ function withoutFencedCode(contents) {
           containers: parsed.containers,
         };
       }
-      return "";
+      output.push("");
+      continue;
     }
     const opening = parsed.content.match(/^[ \t]{0,3}(`{3,}|~{3,})(.*)$/);
     if (opening && !(opening[1][0] === "`" && opening[2].includes("`"))) {
@@ -440,10 +454,12 @@ function withoutFencedCode(contents) {
         length: opening[1].length,
         containers: parsed.containers,
       };
-      return "";
+      output.push("");
+      continue;
     }
-    return line;
-  }).join("\n");
+    output.push(line);
+  }
+  return output.join("\n");
 }
 
 function htmlBlockAt(content) {

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -442,6 +442,9 @@ function paragraphOpenAfter(line, paragraphOpen) {
   }
   const list = listMarkerPrefix(value);
   if (list) {
+    if (stripIndent(value.slice(list.length), 4) !== null) {
+      return paragraphOpen;
+    }
     if (list.empty && value.trim() !== "-") {
       return paragraphOpen;
     }

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -229,6 +229,36 @@ function parseBlockContainers(line, orderedListCanInterrupt = null) {
   }
 }
 
+function parseContinuedBlockContainers(
+  line,
+  activeContainers,
+  activeParagraphOpen,
+  orderedListCanInterrupt,
+) {
+  const continued = blockContainerPrefix(line, activeContainers);
+  let containers = activeContainers.slice(0, continued.count);
+  let content = continued.content;
+  if (continued.count < activeContainers.length && activeParagraphOpen &&
+      paragraphOpenAfter(content, true)) {
+    containers = activeContainers;
+  } else if (continued.count < activeContainers.length && !content.trim()) {
+    for (let count = activeContainers.length; count > continued.count; count--) {
+      if (blankWithinBlockContainers(line, activeContainers.slice(0, count))) {
+        containers = activeContainers.slice(0, count);
+        content = "";
+        break;
+      }
+    }
+  }
+
+  const nested = parseBlockContainers(content, (nestedContainers) =>
+    orderedListCanInterrupt([...containers, ...nestedContainers]));
+  return {
+    content: nested.content,
+    containers: [...containers, ...nested.containers],
+  };
+}
+
 function listMarkerPrefix(value) {
   const marker = value.match(/^( {0,3})(?:[-+*]|(\d{1,9})[.)])/);
   if (!marker) {
@@ -240,11 +270,19 @@ function listMarkerPrefix(value) {
     return null;
   }
   const markerColumn = indentationWidth(value.slice(0, index));
+  const firstPaddingEnd = index + 1;
+  const firstPaddingColumn = value[index] === "\t"
+    ? markerColumn + 4 - (markerColumn % 4)
+    : markerColumn + 1;
   let column = markerColumn;
   while (value[index] === " " || value[index] === "\t") {
     column = value[index] === "\t" ? column + 4 - (column % 4) : column + 1;
     if (column - markerColumn > 4) {
-      return null;
+      return {
+        length: firstPaddingEnd,
+        indent: firstPaddingColumn,
+        orderedStart: marker[2] === undefined ? null : Number(marker[2]),
+      };
     }
     index++;
   }
@@ -283,7 +321,8 @@ function paragraphOpenBefore(lines, index, containers, paragraphCache) {
     state.index++;
     const content = continueBlockContainers(lines[previous], containers);
     if (content === null) {
-      state.paragraphOpen = false;
+      state.paragraphOpen = state.paragraphOpen &&
+        lazyParagraphContinuation(lines[previous], containers);
       continue;
     }
     const nextParagraphOpen = paragraphOpenAfter(content, state.paragraphOpen);
@@ -323,22 +362,36 @@ function paragraphOpenAfter(line, paragraphOpen) {
 }
 
 function continueBlockContainers(line, containers) {
+  const continued = blockContainerPrefix(line, containers);
+  return continued.count === containers.length ? continued.content : null;
+}
+
+function blockContainerPrefix(line, containers) {
   let remaining = line.replace(/\r$/, "");
+  let count = 0;
   for (const container of containers) {
     if (container.type === "quote") {
       const quote = remaining.match(/^ {0,3}>[ \t]?/);
       if (!quote) {
-        return null;
+        break;
       }
       remaining = remaining.slice(quote[0].length);
-      continue;
+    } else {
+      const stripped = stripIndent(remaining, container.indent);
+      if (stripped === null) {
+        break;
+      }
+      remaining = stripped;
     }
-    remaining = stripIndent(remaining, container.indent);
-    if (remaining === null) {
-      return null;
-    }
+    count++;
   }
-  return remaining;
+  return { content: remaining, count };
+}
+
+function lazyParagraphContinuation(line, containers) {
+  const continued = blockContainerPrefix(line, containers);
+  return continued.count < containers.length &&
+    paragraphOpenAfter(continued.content, true);
 }
 
 function blankWithinBlockContainers(line, containers) {
@@ -396,6 +449,7 @@ function isExternal(target) {
 function withoutFencedCode(contents) {
   let fence = null;
   let htmlBlock = null;
+  let activeContainers = [];
   const output = [];
   const paragraphCache = new Map();
   for (const line of contents.split("\n")) {
@@ -432,10 +486,28 @@ function withoutFencedCode(contents) {
       htmlBlock = null;
     }
 
-    const parsed = parseBlockContainers(line, (containers) =>
+    const orderedListCanInterrupt = (containers) =>
       !paragraphOpenBefore(
         output, output.length, containers, paragraphCache,
-      ));
+      );
+    const parsed = activeContainers.length
+      ? parseContinuedBlockContainers(
+        line,
+        activeContainers,
+        paragraphOpenBefore(
+          output, output.length, activeContainers, paragraphCache,
+        ),
+        orderedListCanInterrupt,
+      )
+      : parseBlockContainers(line, orderedListCanInterrupt);
+    activeContainers = parsed.containers;
+    if (stripIndent(parsed.content, 4) !== null &&
+        !paragraphOpenBefore(
+          output, output.length, parsed.containers, paragraphCache,
+        )) {
+      output.push("");
+      continue;
+    }
     const openingHTML = htmlBlockAt(parsed.content);
     if (openingHTML) {
       if (!openingHTML.terminator.test(parsed.content)) {

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -450,6 +450,9 @@ function paragraphOpenAfter(line, paragraphOpen) {
     }
     return paragraphOpen && list.orderedStart !== null && list.orderedStart !== 1;
   }
+  if (gfmTableDelimiter(value)) {
+    return false;
+  }
   if (/^(?: {4}|\t)/.test(value)) {
     return paragraphOpen;
   }
@@ -463,6 +466,16 @@ function paragraphOpenAfter(line, paragraphOpen) {
     return paragraphOpen;
   }
   return true;
+}
+
+function gfmTableDelimiter(line) {
+  const row = line.match(/^ {0,3}(.*)$/)?.[1]?.trim();
+  if (!row?.includes("|")) {
+    return false;
+  }
+  const cells = row.replace(/^\|/, "").replace(/\|$/, "").split("|");
+  return cells.length > 0 &&
+    cells.every((cell) => /^:?-{3,}:?$/.test(cell.trim()));
 }
 
 function continueBlockContainers(line, containers) {

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -59,8 +59,8 @@ export function markdownTargets(contents) {
 }
 
 function referenceDefinitionAt(lines, index) {
-  const line = stripBlockContainers(lines[index]);
-  const match = line.match(
+  const parsedLine = parseBlockContainers(lines[index]);
+  const match = parsedLine.content.match(
     /^[ \t]{0,3}\[(?!\^)((?:\\.|[^\]\\\n])+)\]:[ \t]*(.*)$/,
   );
   if (!match) {
@@ -73,7 +73,12 @@ function referenceDefinitionAt(lines, index) {
     if (index + 1 >= lines.length) {
       return null;
     }
-    const continuation = stripBlockContainers(lines[index + 1]);
+    const continuation = continueBlockContainers(
+      lines[index + 1], parsedLine.containers,
+    );
+    if (continuation === null) {
+      return null;
+    }
     if (/^[ \t]{0,3}\[(?!\^)(?:\\.|[^\]\\\n])+\]:/.test(continuation)) {
       return null;
     }
@@ -119,12 +124,14 @@ function referenceTitle(value) {
   return /^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))$/.test(value);
 }
 
-function stripBlockContainers(line) {
+function parseBlockContainers(line) {
   let remaining = line.replace(/\r$/, "");
+  const containers = [];
   while (true) {
     const quote = remaining.match(/^[ \t]{0,3}>[ \t]?/);
     if (quote) {
       remaining = remaining.slice(quote[0].length);
+      containers.push({ type: "quote" });
       continue;
     }
     const list = remaining.match(
@@ -132,10 +139,54 @@ function stripBlockContainers(line) {
     );
     if (list) {
       remaining = remaining.slice(list[0].length);
+      containers.push({ type: "list", indent: indentationWidth(list[0]) });
       continue;
     }
-    return remaining;
+    return { content: remaining, containers };
   }
+}
+
+function continueBlockContainers(line, containers) {
+  let remaining = line.replace(/\r$/, "");
+  for (const container of containers) {
+    if (container.type === "quote") {
+      const quote = remaining.match(/^[ \t]{0,3}>[ \t]?/);
+      if (!quote) {
+        return null;
+      }
+      remaining = remaining.slice(quote[0].length);
+      continue;
+    }
+    remaining = stripIndent(remaining, container.indent);
+    if (remaining === null) {
+      return null;
+    }
+  }
+  return remaining;
+}
+
+function indentationWidth(value) {
+  let column = 0;
+  for (const character of value) {
+    column = character === "\t" ? column + 4 - (column % 4) : column + 1;
+  }
+  return column;
+}
+
+function stripIndent(line, width) {
+  let column = 0;
+  let index = 0;
+  while (index < line.length && column < width) {
+    if (line[index] === " ") {
+      column++;
+    } else if (line[index] === "\t") {
+      column += 4 - (column % 4);
+    } else {
+      return null;
+    }
+    index++;
+  }
+  return column < width ? null : `${" ".repeat(column - width)}${line.slice(index)}`;
 }
 
 function isExternal(target) {
@@ -143,18 +194,34 @@ function isExternal(target) {
 }
 
 function withoutFencedCode(contents) {
-  let fence = "";
+  let fence = null;
   return contents.split("\n").map((line) => {
-    const marker = stripBlockContainers(line).match(/^\s*(```+|~~~+)/)?.[1] || "";
-    if (marker && !fence) {
-      fence = marker[0];
+    if (fence) {
+      const content = continueBlockContainers(line, fence.containers);
+      if (content !== null) {
+        const closing = content.match(/^[ \t]{0,3}(`+|~+)[ \t]*$/)?.[1] || "";
+        if (closing[0] === fence.character && closing.length >= fence.length) {
+          fence = null;
+        }
+        return "";
+      }
+      if (!line.trim() && !fence.containers.some(({ type }) => type === "quote")) {
+        return "";
+      }
+      fence = null;
+    }
+
+    const parsed = parseBlockContainers(line);
+    const opening = parsed.content.match(/^[ \t]{0,3}(`{3,}|~{3,})(.*)$/);
+    if (opening && !(opening[1][0] === "`" && opening[2].includes("`"))) {
+      fence = {
+        character: opening[1][0],
+        length: opening[1].length,
+        containers: parsed.containers,
+      };
       return "";
     }
-    if (marker && fence === marker[0]) {
-      fence = "";
-      return "";
-    }
-    return fence ? "" : line;
+    return line;
   }).join("\n");
 }
 

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -628,6 +628,7 @@ function withoutFencedCode(contents) {
   const paragraphCache = new Map();
   const definitionParagraphCache = new Map();
   const lines = contents.split("\n");
+  const definitionLines = lines.slice();
   for (let index = 0; index < lines.length; index++) {
     const line = lines[index];
     if (fence) {
@@ -638,11 +639,13 @@ function withoutFencedCode(contents) {
         if (closing[0] === fence.character && closing.length >= fence.length) {
           fence = null;
         }
-        output.push(maskedContainerLine(containers));
+        appendMaskedLine(output, definitionLines, index, containers);
         continue;
       }
       if (blankWithinBlockContainers(line, fence.containers)) {
-        output.push(maskedContainerLine(fence.containers));
+        appendMaskedLine(
+          output, definitionLines, index, fence.containers,
+        );
         continue;
       }
       fence = null;
@@ -656,7 +659,7 @@ function withoutFencedCode(contents) {
             htmlBlock.terminator?.test(content)) {
           htmlBlock = null;
         }
-        output.push(maskedContainerLine(containers));
+        appendMaskedLine(output, definitionLines, index, containers);
         continue;
       }
       if (blankWithinBlockContainers(line, htmlBlock.containers)) {
@@ -664,7 +667,7 @@ function withoutFencedCode(contents) {
         if (htmlBlock.endsOnBlank) {
           htmlBlock = null;
         }
-        output.push(maskedContainerLine(containers));
+        appendMaskedLine(output, definitionLines, index, containers);
         continue;
       }
       htmlBlock = null;
@@ -691,7 +694,7 @@ function withoutFencedCode(contents) {
       : parseBlockContainers(line, orderedListCanInterrupt);
     activeContainers = parsed.containers;
     const definition = referenceDefinitionAt(
-      lines, index, true, definitionParagraphCache, parsed,
+      definitionLines, index, true, definitionParagraphCache, parsed,
     );
     if (definition?.consumed) {
       referenceContinuationThrough = index + definition.consumed;
@@ -701,7 +704,7 @@ function withoutFencedCode(contents) {
          !paragraphOpenBefore(
            output, output.length, parsed.containers, paragraphCache,
          ))) {
-      output.push(maskedContainerLine(parsed.containers));
+      appendMaskedLine(output, definitionLines, index, parsed.containers);
       continue;
     }
     const openingHTML = htmlBlockAt(parsed.content);
@@ -714,7 +717,7 @@ function withoutFencedCode(contents) {
           containers: parsed.containers,
         };
       }
-      output.push(maskedContainerLine(parsed.containers));
+      appendMaskedLine(output, definitionLines, index, parsed.containers);
       continue;
     }
     const opening = fencedCodeOpening(parsed.content);
@@ -724,12 +727,18 @@ function withoutFencedCode(contents) {
         length: opening.length,
         containers: parsed.containers,
       };
-      output.push(maskedContainerLine(parsed.containers));
+      appendMaskedLine(output, definitionLines, index, parsed.containers);
       continue;
     }
     output.push(line);
   }
   return output.join("\n");
+}
+
+function appendMaskedLine(output, definitionLines, index, containers) {
+  const masked = maskedContainerLine(containers);
+  definitionLines[index] = masked;
+  output.push(masked);
 }
 
 function maskedContainerLine(containers) {

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -394,7 +394,12 @@ function paragraphOpenBefore(lines, index, containers, paragraphCache) {
       (container.orderedStart === null ? "bullet" : "ordered")).join("/");
   let state = cache.get(key);
   if (!state || state.index > index) {
-    state = { index: 0, paragraphOpen: false, paragraphStart: -1 };
+    state = {
+      index: 0,
+      paragraphOpen: false,
+      paragraphStart: -1,
+      tableOpen: false,
+    };
     cache.set(key, state);
   }
   while (state.index < index) {
@@ -403,11 +408,13 @@ function paragraphOpenBefore(lines, index, containers, paragraphCache) {
     if (startsNewListItem(lines[previous], containers)) {
       state.paragraphOpen = false;
       state.paragraphStart = -1;
+      state.tableOpen = false;
     }
     const content = paragraphContentWithinContainers(
       lines[previous], containers,
     );
     if (content === null) {
+      state.tableOpen = false;
       state.paragraphOpen = state.paragraphOpen &&
         lazyParagraphContinuation(lines[previous], containers);
       if (!state.paragraphOpen) {
@@ -415,10 +422,33 @@ function paragraphOpenBefore(lines, index, containers, paragraphCache) {
       }
       continue;
     }
+    if (state.tableOpen) {
+      const nestedLine = parseBlockContainers(content);
+      const definition = referenceDefinitionAt(
+        lines,
+        previous,
+        false,
+        null,
+        {
+          content: nestedLine.content,
+          containers: [...containers, ...nestedLine.containers],
+        },
+      );
+      const apparentDefinition = nestedLine.containers.length === 0 &&
+        /^[ \t]{0,3}\[(?!\^)(?:\\.|[^\]\\\n])+\]:/.test(content);
+      if (paragraphOpenAfter(content, false) ||
+          (apparentDefinition && !definition)) {
+        state.paragraphOpen = false;
+        state.paragraphStart = -1;
+        continue;
+      }
+      state.tableOpen = false;
+    }
     const wasOpen = state.paragraphOpen;
     const tableHeader = wasOpen && state.paragraphStart === previous - 1
       ? paragraphContentWithinContainers(lines[previous - 1], containers)
       : null;
+    const startsTable = gfmTableDelimiter(content, tableHeader);
     const nextParagraphOpen = paragraphOpenAfter(
       content, wasOpen, tableHeader,
     );
@@ -445,6 +475,7 @@ function paragraphOpenBefore(lines, index, containers, paragraphCache) {
     state.paragraphStart = nextParagraphOpen
       ? (wasOpen ? state.paragraphStart : previous)
       : -1;
+    state.tableOpen = startsTable;
   }
   return !startsNewListItem(lines[index], containers) && state.paragraphOpen;
 }

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -17,6 +17,18 @@ const blankTerminatedHTMLTags = new Set([
   "search", "section", "summary", "table", "tbody", "td", "tfoot", "th",
   "thead", "title", "tr", "track", "ul",
 ]);
+const htmlWhitespace = "[\\t\\n\\v\\f\\r ]";
+const htmlTagName = "[A-Za-z][A-Za-z0-9-]*";
+const htmlAttributeName = "[A-Za-z_:][A-Za-z0-9_.:-]*";
+const htmlAttributeValue =
+  "(?:[^\\t\\n\\v\\f\\r \"'=<>`]+|'[^']*'|\"[^\"]*\")";
+const htmlAttribute = `${htmlWhitespace}+${htmlAttributeName}` +
+  `(?:${htmlWhitespace}*=${htmlWhitespace}*${htmlAttributeValue})?`;
+const typeSevenHTMLTag = new RegExp(
+  `^ {0,3}(?:<${htmlTagName}(?:${htmlAttribute})*` +
+  `${htmlWhitespace}*/?>|</${htmlTagName}${htmlWhitespace}*>` +
+  `)${htmlWhitespace}*$`,
+);
 
 export function checkMarkdownLinks(root, markdownFile, contents) {
   const failures = [];
@@ -511,7 +523,7 @@ function paragraphOpenAfter(line, paragraphOpen, tableHeader = null) {
   }
   if (/^ {0,3}(?:#{1,6}(?:[ \t]+|$)|>)/.test(value) ||
       fencedCodeOpening(value) ||
-      htmlBlockAt(value) ||
+      htmlBlockAt(value, !paragraphOpen) ||
       /^ {0,3}(?:(?:\*[ \t]*){3,}|(?:_[ \t]*){3,}|(?:-[ \t]*)+|=+[ \t]*)$/.test(value)) {
     return false;
   }
@@ -838,7 +850,12 @@ function withoutFencedCode(contents) {
       appendMaskedLine(output, definitionLines, index, parsed.containers);
       continue;
     }
-    const openingHTML = htmlBlockAt(parsed.content);
+    const openingHTML = htmlBlockAt(
+      parsed.content,
+      !paragraphOpenBefore(
+        output, output.length, parsed.containers, paragraphCache,
+      ),
+    );
     if (openingHTML) {
       if (openingHTML.endsOnBlank ||
           !openingHTML.terminator.test(parsed.content)) {
@@ -900,7 +917,7 @@ function fencedCodeOpening(content) {
   return { character: opening[1][0], length: opening[1].length };
 }
 
-function htmlBlockAt(content) {
+function htmlBlockAt(content, allowTypeSeven = false) {
   const typeOne = content.match(/^ {0,3}<(script|pre|style|textarea)(?:[ \t]|>|$)/i);
   if (typeOne) {
     return { terminator: new RegExp(`</${typeOne[1]}[ \\t]*>`, "i") };
@@ -921,6 +938,9 @@ function htmlBlockAt(content) {
     /^ {0,3}<\/?([A-Za-z][A-Za-z0-9-]*)(?=[ \t]|\/?>|$)/,
   );
   if (blankTerminatedHTMLTags.has(blankTerminated?.[1]?.toLowerCase())) {
+    return { endsOnBlank: true };
+  }
+  if (allowTypeSeven && typeSevenHTMLTag.test(content)) {
     return { endsOnBlank: true };
   }
   return null;

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -236,7 +236,7 @@ function parseBlockContainers(line, orderedListCanInterrupt = null) {
           orderedListCanInterrupt && !orderedListCanInterrupt(containers)) {
         return { content: remaining, containers };
       }
-      remaining = remaining.slice(list.length);
+      remaining = expandTabs(remaining.slice(list.length), list.indent);
       containers.push({
         type: "list",
         indent: list.indent,
@@ -265,7 +265,7 @@ function stripBlockQuoteMarker(line) {
   }
   const whitespaceWidth = column - whitespaceStartColumn;
   const contentIndent = whitespaceWidth > 0 ? whitespaceWidth - 1 : 0;
-  return `${" ".repeat(contentIndent)}${line.slice(index)}`;
+  return `${" ".repeat(contentIndent)}${expandTabs(line.slice(index), column)}`;
 }
 
 function parseContinuedBlockContainers(
@@ -453,7 +453,7 @@ function paragraphContentWithinContainers(line, containers) {
     }
     const marker = listMarkerPrefix(remaining);
     if (marker?.markerIndent === container.markerIndent) {
-      remaining = remaining.slice(marker.length);
+      remaining = expandTabs(remaining.slice(marker.length), marker.indent);
       continue;
     }
     const stripped = stripIndent(remaining, container.indent);
@@ -552,6 +552,22 @@ function indentationWidth(value) {
   return column;
 }
 
+function expandTabs(value, initialColumn) {
+  let column = initialColumn;
+  let expanded = "";
+  for (const character of value) {
+    if (character === "\t") {
+      const width = 4 - (column % 4);
+      expanded += " ".repeat(width);
+      column += width;
+    } else {
+      expanded += character;
+      column++;
+    }
+  }
+  return expanded;
+}
+
 function stripIndent(line, width) {
   let column = 0;
   let index = 0;
@@ -564,7 +580,9 @@ function stripIndent(line, width) {
     }
     index++;
   }
-  return column < width ? null : `${" ".repeat(column - width)}${line.slice(index)}`;
+  return column < width
+    ? null
+    : `${" ".repeat(column - width)}${expandTabs(line.slice(index), column)}`;
 }
 
 function isExternal(target) {

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -442,6 +442,7 @@ function paragraphOpenAfter(line, paragraphOpen) {
   }
   if (/^ {0,3}(?:#{1,6}(?:[ \t]+|$)|>)/.test(value) ||
       fencedCodeOpening(value) ||
+      htmlBlockAt(value) ||
       /^ {0,3}(?:(?:\*[ \t]*){3,}|(?:_[ \t]*){3,}|(?:-[ \t]*)+|=+[ \t]*)$/.test(value)) {
     return false;
   }

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -388,7 +388,17 @@ function paragraphOpenBefore(lines, index, containers, paragraphCache) {
     }
     const nextParagraphOpen = paragraphOpenAfter(content, state.paragraphOpen);
     if (!state.paragraphOpen || !nextParagraphOpen) {
-      const definition = referenceDefinitionAt(lines, previous, false);
+      const nestedLine = parseBlockContainers(content);
+      const definition = referenceDefinitionAt(
+        lines,
+        previous,
+        false,
+        null,
+        {
+          content: nestedLine.content,
+          containers: [...containers, ...nestedLine.containers],
+        },
+      );
       if (definition) {
         state.paragraphOpen = false;
         state.index += definition.consumed;

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -7,6 +7,16 @@ import { fileURLToPath } from "node:url";
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const scriptPath = fileURLToPath(import.meta.url);
+const blankTerminatedHTMLTags = new Set([
+  "address", "article", "aside", "base", "basefont", "blockquote", "body",
+  "caption", "center", "col", "colgroup", "dd", "details", "dialog", "dir",
+  "div", "dl", "dt", "fieldset", "figcaption", "figure", "footer", "form",
+  "frame", "frameset", "h1", "h2", "h3", "h4", "h5", "h6", "head",
+  "header", "hr", "html", "iframe", "legend", "li", "link", "main", "menu",
+  "menuitem", "nav", "noframes", "ol", "optgroup", "option", "p", "param",
+  "search", "section", "summary", "table", "tbody", "td", "tfoot", "th",
+  "thead", "title", "tr", "track", "ul",
+]);
 
 export function checkMarkdownLinks(root, markdownFile, contents) {
   const failures = [];
@@ -639,14 +649,19 @@ function withoutFencedCode(contents) {
       const content = continueBlockContainers(line, htmlBlock.containers);
       if (content !== null) {
         const containers = htmlBlock.containers;
-        if (htmlBlock.terminator.test(content)) {
+        if ((htmlBlock.endsOnBlank && !content.trim()) ||
+            htmlBlock.terminator?.test(content)) {
           htmlBlock = null;
         }
         output.push(maskedContainerLine(containers));
         continue;
       }
       if (blankWithinBlockContainers(line, htmlBlock.containers)) {
-        output.push(maskedContainerLine(htmlBlock.containers));
+        const containers = htmlBlock.containers;
+        if (htmlBlock.endsOnBlank) {
+          htmlBlock = null;
+        }
+        output.push(maskedContainerLine(containers));
         continue;
       }
       htmlBlock = null;
@@ -688,8 +703,10 @@ function withoutFencedCode(contents) {
     }
     const openingHTML = htmlBlockAt(parsed.content);
     if (openingHTML) {
-      if (!openingHTML.terminator.test(parsed.content)) {
+      if (openingHTML.endsOnBlank ||
+          !openingHTML.terminator.test(parsed.content)) {
         htmlBlock = {
+          endsOnBlank: openingHTML.endsOnBlank,
           terminator: openingHTML.terminator,
           containers: parsed.containers,
         };
@@ -752,6 +769,12 @@ function htmlBlockAt(content) {
   }
   if (/^ {0,3}<![A-Z]/.test(content)) {
     return { terminator: />/ };
+  }
+  const blankTerminated = content.match(
+    /^ {0,3}<\/?([A-Za-z][A-Za-z0-9-]*)(?=[ \t]|\/?>|$)/,
+  );
+  if (blankTerminatedHTMLTags.has(blankTerminated?.[1]?.toLowerCase())) {
+    return { endsOnBlank: true };
   }
   return null;
 }

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -58,8 +58,12 @@ export function markdownTargets(contents) {
   return targets;
 }
 
-function referenceDefinitionAt(lines, index) {
+function referenceDefinitionAt(lines, index, checkParagraphInterruption = true) {
   const parsedLine = parseBlockContainers(lines[index]);
+  if (checkParagraphInterruption &&
+      orderedListInterruptsParagraph(lines, index, parsedLine.containers)) {
+    return null;
+  }
   const match = parsedLine.content.match(
     /^[ \t]{0,3}\[(?!\^)((?:\\.|[^\]\\\n])+)\]:[ \t]*(.*)$/,
   );
@@ -191,7 +195,7 @@ function parseBlockContainers(line) {
   let remaining = line.replace(/\r$/, "");
   const containers = [];
   while (true) {
-    const quote = remaining.match(/^[ \t]{0,3}>[ \t]?/);
+    const quote = remaining.match(/^ {0,3}>[ \t]?/);
     if (quote) {
       remaining = remaining.slice(quote[0].length);
       containers.push({ type: "quote" });
@@ -200,7 +204,11 @@ function parseBlockContainers(line) {
     const list = listMarkerPrefix(remaining);
     if (list) {
       remaining = remaining.slice(list.length);
-      containers.push({ type: "list", indent: list.indent });
+      containers.push({
+        type: "list",
+        indent: list.indent,
+        orderedStart: list.orderedStart,
+      });
       continue;
     }
     return { content: remaining, containers };
@@ -208,7 +216,7 @@ function parseBlockContainers(line) {
 }
 
 function listMarkerPrefix(value) {
-  const marker = value.match(/^( {0,3})(?:[-+*]|\d{1,9}[.)])/);
+  const marker = value.match(/^( {0,3})(?:[-+*]|(\d{1,9})[.)])/);
   if (!marker) {
     return null;
   }
@@ -226,14 +234,73 @@ function listMarkerPrefix(value) {
     }
     index++;
   }
-  return { length: index, indent: column };
+  return {
+    length: index,
+    indent: column,
+    orderedStart: marker[2] === undefined ? null : Number(marker[2]),
+  };
+}
+
+function orderedListInterruptsParagraph(lines, index, containers) {
+  const listIndex = containers.findIndex((container) =>
+    container.type === "list" &&
+    container.orderedStart !== null &&
+    container.orderedStart !== 1);
+  if (listIndex < 0) {
+    return false;
+  }
+  return paragraphOpenBefore(lines, index, containers.slice(0, listIndex));
+}
+
+function paragraphOpenBefore(lines, index, containers) {
+  let paragraphOpen = false;
+  for (let previous = 0; previous < index; previous++) {
+    const content = continueBlockContainers(lines[previous], containers);
+    if (content === null) {
+      paragraphOpen = false;
+      continue;
+    }
+    const nextParagraphOpen = paragraphOpenAfter(content, paragraphOpen);
+    if (!paragraphOpen || !nextParagraphOpen) {
+      const definition = referenceDefinitionAt(lines, previous, false);
+      if (definition) {
+        paragraphOpen = false;
+        previous += definition.consumed;
+        continue;
+      }
+    }
+    paragraphOpen = nextParagraphOpen;
+  }
+  return paragraphOpen;
+}
+
+function paragraphOpenAfter(line, paragraphOpen) {
+  const value = line.replace(/\r$/, "");
+  if (!value.trim()) {
+    return false;
+  }
+  const list = listMarkerPrefix(value);
+  if (list) {
+    return paragraphOpen && list.orderedStart !== null && list.orderedStart !== 1;
+  }
+  if (/^(?: {4}|\t)/.test(value)) {
+    return paragraphOpen;
+  }
+  if (/^ {0,3}(?:#{1,6}(?:[ \t]+|$)|>|`{3,}|~{3,})/.test(value) ||
+      /^ {0,3}(?:(?:\*[ \t]*){3,}|(?:_[ \t]*){3,}|(?:-[ \t]*){3,}|=+[ \t]*)$/.test(value)) {
+    return false;
+  }
+  if (/^ {0,3}\[(?!\^)(?:\\.|[^\]\\\n])+\]:/.test(value)) {
+    return paragraphOpen;
+  }
+  return true;
 }
 
 function continueBlockContainers(line, containers) {
   let remaining = line.replace(/\r$/, "");
   for (const container of containers) {
     if (container.type === "quote") {
-      const quote = remaining.match(/^[ \t]{0,3}>[ \t]?/);
+      const quote = remaining.match(/^ {0,3}>[ \t]?/);
       if (!quote) {
         return null;
       }
@@ -252,7 +319,7 @@ function blankWithinBlockContainers(line, containers) {
   let remaining = line.replace(/\r$/, "");
   for (const container of containers) {
     if (container.type === "quote") {
-      const quote = remaining.match(/^[ \t]{0,3}>[ \t]?/);
+      const quote = remaining.match(/^ {0,3}>[ \t]?/);
       if (!quote) {
         return false;
       }

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -47,12 +47,93 @@ export function markdownTargets(contents) {
   )) {
     targets.push(match[1].replace(/^<|>$/g, ""));
   }
-  for (const match of markdown.matchAll(
-    /^[ \t]{0,3}\[(?!\^)[^\]\n]+\]:[ \t]*(?:\r?\n[ \t]{0,3})?(?:<([^>\n]+)>|([^\s]+))/gm,
-  )) {
-    targets.push(match[1] || match[2]);
+  const lines = markdown.split("\n");
+  for (let index = 0; index < lines.length; index++) {
+    const definition = referenceDefinitionAt(lines, index);
+    if (definition) {
+      targets.push(definition.target);
+      index += definition.continued ? 1 : 0;
+    }
   }
   return targets;
+}
+
+function referenceDefinitionAt(lines, index) {
+  const line = stripBlockContainers(lines[index]);
+  const match = line.match(
+    /^[ \t]{0,3}\[(?!\^)((?:\\.|[^\]\\\n])+)\]:[ \t]*(.*)$/,
+  );
+  if (!match) {
+    return null;
+  }
+
+  let remainder = match[2];
+  let continued = false;
+  if (!remainder.trim()) {
+    if (index + 1 >= lines.length) {
+      return null;
+    }
+    const continuation = stripBlockContainers(lines[index + 1]);
+    if (/^[ \t]{0,3}\[(?!\^)(?:\\.|[^\]\\\n])+\]:/.test(continuation)) {
+      return null;
+    }
+    const continuationMatch = continuation.match(/^[ \t]{0,3}(\S.*)$/);
+    if (!continuationMatch) {
+      return null;
+    }
+    remainder = continuationMatch[1];
+    continued = true;
+  }
+
+  const target = referenceDestination(remainder);
+  return target === null ? null : { target, continued };
+}
+
+function referenceDestination(remainder) {
+  const value = remainder.trim();
+  let target;
+  let trailing;
+  if (value.startsWith("<")) {
+    const match = value.match(/^<((?:\\.|[^<>\\\n])*)>(.*)$/);
+    if (!match) {
+      return null;
+    }
+    target = match[1];
+    trailing = match[2].trim();
+  } else {
+    const match = value.match(/^(\S+)(.*)$/);
+    if (!match) {
+      return null;
+    }
+    target = match[1];
+    trailing = match[2].trim();
+  }
+
+  if (trailing && !referenceTitle(trailing)) {
+    return null;
+  }
+  return target;
+}
+
+function referenceTitle(value) {
+  return /^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))$/.test(value);
+}
+
+function stripBlockContainers(line) {
+  let remaining = line.replace(/\r$/, "");
+  while (true) {
+    const quote = remaining.match(/^[ \t]{0,3}>[ \t]?/);
+    if (quote) {
+      remaining = remaining.slice(quote[0].length);
+      continue;
+    }
+    const list = remaining.match(/^[ \t]{0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+/);
+    if (list) {
+      remaining = remaining.slice(list[0].length);
+      continue;
+    }
+    return remaining;
+  }
 }
 
 function isExternal(target) {

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -723,7 +723,8 @@ function maskedContainerLine(containers) {
     line += `${" ".repeat(container.markerIndent)}${container.marker}` +
       " ".repeat(Math.max(1, padding));
   }
-  return line;
+  // Keep list markers nonempty so an interrupting `1.` block stays interrupting.
+  return line ? `${line}#` : "";
 }
 
 function fencedCodeOpening(content) {

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -425,7 +425,8 @@ function paragraphOpenAfter(line, paragraphOpen) {
   if (/^(?: {4}|\t)/.test(value)) {
     return paragraphOpen;
   }
-  if (/^ {0,3}(?:#{1,6}(?:[ \t]+|$)|>|`{3,}|~{3,})/.test(value) ||
+  if (/^ {0,3}(?:#{1,6}(?:[ \t]+|$)|>)/.test(value) ||
+      fencedCodeOpening(value) ||
       /^ {0,3}(?:(?:\*[ \t]*){3,}|(?:_[ \t]*){3,}|(?:-[ \t]*)+|=+[ \t]*)$/.test(value)) {
     return false;
   }
@@ -663,11 +664,11 @@ function withoutFencedCode(contents) {
       output.push("");
       continue;
     }
-    const opening = parsed.content.match(/^[ \t]{0,3}(`{3,}|~{3,})(.*)$/);
-    if (opening && !(opening[1][0] === "`" && opening[2].includes("`"))) {
+    const opening = fencedCodeOpening(parsed.content);
+    if (opening) {
       fence = {
-        character: opening[1][0],
-        length: opening[1].length,
+        character: opening.character,
+        length: opening.length,
         containers: parsed.containers,
       };
       output.push("");
@@ -676,6 +677,14 @@ function withoutFencedCode(contents) {
     output.push(line);
   }
   return output.join("\n");
+}
+
+function fencedCodeOpening(content) {
+  const opening = content.match(/^[ \t]{0,3}(`{3,}|~{3,})(.*)$/);
+  if (!opening || (opening[1][0] === "`" && opening[2].includes("`"))) {
+    return null;
+  }
+  return { character: opening[1][0], length: opening[1].length };
 }
 
 function htmlBlockAt(content) {

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -394,7 +394,7 @@ function paragraphOpenBefore(lines, index, containers, paragraphCache) {
       (container.orderedStart === null ? "bullet" : "ordered")).join("/");
   let state = cache.get(key);
   if (!state || state.index > index) {
-    state = { index: 0, paragraphOpen: false };
+    state = { index: 0, paragraphOpen: false, paragraphStart: -1 };
     cache.set(key, state);
   }
   while (state.index < index) {
@@ -402,6 +402,7 @@ function paragraphOpenBefore(lines, index, containers, paragraphCache) {
     state.index++;
     if (startsNewListItem(lines[previous], containers)) {
       state.paragraphOpen = false;
+      state.paragraphStart = -1;
     }
     const content = paragraphContentWithinContainers(
       lines[previous], containers,
@@ -409,9 +410,18 @@ function paragraphOpenBefore(lines, index, containers, paragraphCache) {
     if (content === null) {
       state.paragraphOpen = state.paragraphOpen &&
         lazyParagraphContinuation(lines[previous], containers);
+      if (!state.paragraphOpen) {
+        state.paragraphStart = -1;
+      }
       continue;
     }
-    const nextParagraphOpen = paragraphOpenAfter(content, state.paragraphOpen);
+    const wasOpen = state.paragraphOpen;
+    const tableHeader = wasOpen && state.paragraphStart === previous - 1
+      ? paragraphContentWithinContainers(lines[previous - 1], containers)
+      : null;
+    const nextParagraphOpen = paragraphOpenAfter(
+      content, wasOpen, tableHeader,
+    );
     if (!state.paragraphOpen || !nextParagraphOpen) {
       const nestedLine = parseBlockContainers(content);
       const definition = referenceDefinitionAt(
@@ -426,16 +436,20 @@ function paragraphOpenBefore(lines, index, containers, paragraphCache) {
       );
       if (definition) {
         state.paragraphOpen = false;
+        state.paragraphStart = -1;
         state.index += definition.consumed;
         continue;
       }
     }
     state.paragraphOpen = nextParagraphOpen;
+    state.paragraphStart = nextParagraphOpen
+      ? (wasOpen ? state.paragraphStart : previous)
+      : -1;
   }
   return !startsNewListItem(lines[index], containers) && state.paragraphOpen;
 }
 
-function paragraphOpenAfter(line, paragraphOpen) {
+function paragraphOpenAfter(line, paragraphOpen, tableHeader = null) {
   const value = line.replace(/\r$/, "");
   if (!value.trim()) {
     return false;
@@ -450,7 +464,7 @@ function paragraphOpenAfter(line, paragraphOpen) {
     }
     return paragraphOpen && list.orderedStart !== null && list.orderedStart !== 1;
   }
-  if (gfmTableDelimiter(value)) {
+  if (gfmTableDelimiter(value, tableHeader)) {
     return false;
   }
   if (/^(?: {4}|\t)/.test(value)) {
@@ -468,14 +482,54 @@ function paragraphOpenAfter(line, paragraphOpen) {
   return true;
 }
 
-function gfmTableDelimiter(line) {
-  const row = line.match(/^ {0,3}(.*)$/)?.[1]?.trim();
-  if (!row?.includes("|")) {
+function gfmTableDelimiter(line, header) {
+  const delimiter = gfmTableCells(line);
+  const headerRow = gfmTableCells(header);
+  if (!delimiter?.hasPipe || !headerRow ||
+      delimiter.cells.length !== headerRow.cells.length) {
     return false;
   }
-  const cells = row.replace(/^\|/, "").replace(/\|$/, "").split("|");
-  return cells.length > 0 &&
-    cells.every((cell) => /^:?-{3,}:?$/.test(cell.trim()));
+  return delimiter.cells.every(
+    (cell) => /^:?-{3,}:?$/.test(cell.trim()),
+  );
+}
+
+function gfmTableCells(line) {
+  if (typeof line !== "string") {
+    return null;
+  }
+  const row = line.match(/^ {0,3}(.*)$/)?.[1]?.trim();
+  if (!row) {
+    return null;
+  }
+  const cells = [""];
+  let backslashes = 0;
+  let hasPipe = false;
+  let endedWithPipe = false;
+  for (const character of row) {
+    if (character === "\\") {
+      cells[cells.length - 1] += character;
+      backslashes++;
+      endedWithPipe = false;
+      continue;
+    }
+    if (character === "|" && backslashes % 2 === 0) {
+      cells.push("");
+      hasPipe = true;
+      endedWithPipe = true;
+    } else {
+      cells[cells.length - 1] += character;
+      endedWithPipe = false;
+    }
+    backslashes = 0;
+  }
+  if (row.startsWith("|")) {
+    cells.shift();
+  }
+  if (endedWithPipe) {
+    cells.pop();
+  }
+  return { cells, hasPipe };
 }
 
 function continueBlockContainers(line, containers) {

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -73,7 +73,9 @@ export function markdownTargets(contents) {
         listCanInterrupt,
       )
       : parseBlockContainers(lines[index], listCanInterrupt);
-    activeContainers = parsedLine.containers;
+    activeContainers = footnoteDefinitionOpening(parsedLine.content)
+      ? [...parsedLine.containers, { type: "footnote", indent: 4 }]
+      : parsedLine.containers;
     const definition = referenceDefinitionAt(
       lines, index, true, paragraphCache, parsedLine,
     );
@@ -297,9 +299,13 @@ function parseContinuedBlockContainers(
 ) {
   const continued = blockContainerPrefix(line, activeContainers);
   const startsSiblingListItem = startsNewListItem(line, activeContainers);
+  const leftFootnote = activeContainers.slice(continued.count).some(
+    (container) => container.type === "footnote",
+  );
   let containers = activeContainers.slice(0, continued.count);
   let content = continued.content;
-  if (continued.count < activeContainers.length && activeParagraphOpen &&
+  if (continued.count < activeContainers.length && !leftFootnote &&
+      activeParagraphOpen &&
       paragraphOpenAfter(content, true)) {
     containers = activeContainers;
   } else if (continued.count < activeContainers.length && !content.trim()) {
@@ -330,15 +336,15 @@ function listMarkerPrefix(value) {
 
   let index = marker[0].length;
   const markerColumn = indentationWidth(value.slice(0, index));
-  const empty = !value.slice(index).trim();
-  if (index === value.length) {
+  const empty = /^[ \t]*$/.test(value.slice(index));
+  if (empty) {
     return {
-      length: index,
+      length: value.length,
       indent: markerColumn + 1,
       marker: markerText,
       markerIndent: marker[1].length,
       orderedStart: marker[2] === undefined ? null : Number(marker[2]),
-      empty: true,
+      empty,
     };
   }
   if (value[index] !== " " && value[index] !== "\t") {
@@ -390,8 +396,10 @@ function paragraphOpenBefore(lines, index, containers, paragraphCache) {
   const cache = paragraphCache || new Map();
   const key = containers.map((container) => container.type === "quote"
     ? "quote"
-    : `list:${container.markerIndent}:${container.indent}:` +
-      (container.orderedStart === null ? "bullet" : "ordered")).join("/");
+    : container.type === "footnote"
+      ? "footnote"
+      : `list:${container.markerIndent}:${container.indent}:` +
+        (container.orderedStart === null ? "bullet" : "ordered")).join("/");
   let state = cache.get(key);
   if (!state || state.index > index) {
     state = {
@@ -507,13 +515,17 @@ function paragraphOpenAfter(line, paragraphOpen, tableHeader = null) {
       /^ {0,3}(?:(?:\*[ \t]*){3,}|(?:_[ \t]*){3,}|(?:-[ \t]*)+|=+[ \t]*)$/.test(value)) {
     return false;
   }
-  if (/^ {0,3}\[\^(?:\\.|[^\]\\\n])+\]:/.test(value)) {
+  if (footnoteDefinitionOpening(value)) {
     return false;
   }
   if (/^ {0,3}\[(?!\^)(?:\\.|[^\]\\\n])+\]:/.test(value)) {
     return paragraphOpen;
   }
   return true;
+}
+
+function footnoteDefinitionOpening(line) {
+  return /^ {0,3}\[\^(?:\\.|[^\]\\\n])+\]:/.test(line);
 }
 
 function gfmTableDelimiter(line, header) {
@@ -582,6 +594,14 @@ function paragraphContentWithinContainers(line, containers) {
       remaining = quoteContent;
       continue;
     }
+    if (container.type === "footnote") {
+      const stripped = stripIndent(remaining, container.indent);
+      if (stripped === null) {
+        return null;
+      }
+      remaining = stripped;
+      continue;
+    }
     const marker = listMarkerPrefix(remaining);
     if (marker?.markerIndent === container.markerIndent) {
       remaining = expandTabs(remaining.slice(marker.length), marker.indent);
@@ -630,6 +650,14 @@ function startsNewListItem(line, containers) {
         return false;
       }
       remaining = quoteContent;
+      continue;
+    }
+    if (container.type === "footnote") {
+      const stripped = stripIndent(remaining, container.indent);
+      if (stripped === null) {
+        return false;
+      }
+      remaining = stripped;
       continue;
     }
     const marker = listMarkerPrefix(remaining);
@@ -793,7 +821,9 @@ function withoutFencedCode(contents) {
         orderedListCanInterrupt,
       )
       : parseBlockContainers(line, orderedListCanInterrupt);
-    activeContainers = parsed.containers;
+    activeContainers = footnoteDefinitionOpening(parsed.content)
+      ? [...parsed.containers, { type: "footnote", indent: 4 }]
+      : parsed.containers;
     const definition = referenceDefinitionAt(
       definitionLines, index, true, definitionParagraphCache, parsed,
     );
@@ -847,6 +877,10 @@ function maskedContainerLine(containers) {
   for (const container of containers) {
     if (container.type === "quote") {
       line += "> ";
+      continue;
+    }
+    if (container.type === "footnote") {
+      line += " ".repeat(container.indent);
       continue;
     }
     const padding = container.indent - container.markerIndent -

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -49,8 +49,24 @@ export function markdownTargets(contents) {
   }
   const lines = markdown.split("\n");
   const paragraphCache = new Map();
+  let activeContainers = [];
   for (let index = 0; index < lines.length; index++) {
-    const definition = referenceDefinitionAt(lines, index, true, paragraphCache);
+    const listCanInterrupt = (containers) =>
+      !paragraphOpenBefore(lines, index, containers, paragraphCache);
+    const parsedLine = activeContainers.length
+      ? parseContinuedBlockContainers(
+        lines[index],
+        activeContainers,
+        paragraphOpenBefore(
+          lines, index, activeContainers, paragraphCache,
+        ),
+        listCanInterrupt,
+      )
+      : parseBlockContainers(lines[index], listCanInterrupt);
+    activeContainers = parsedLine.containers;
+    const definition = referenceDefinitionAt(
+      lines, index, true, paragraphCache, parsedLine,
+    );
     if (definition) {
       targets.push(definition.target);
       index += definition.consumed;
@@ -64,8 +80,9 @@ function referenceDefinitionAt(
   index,
   checkParagraphInterruption = true,
   paragraphCache = null,
+  parsedLineOverride = null,
 ) {
-  const parsedLine = parseBlockContainers(lines[index]);
+  const parsedLine = parsedLineOverride || parseBlockContainers(lines[index]);
   const match = parsedLine.content.match(
     /^[ \t]{0,3}\[(?!\^)((?:\\.|[^\]\\\n])+)\]:[ \t]*(.*)$/,
   );
@@ -329,7 +346,8 @@ function paragraphOpenBefore(lines, index, containers, paragraphCache) {
   const cache = paragraphCache || new Map();
   const key = containers.map((container) => container.type === "quote"
     ? "quote"
-    : `list:${container.indent}:${container.orderedStart ?? "bullet"}`).join("/");
+    : `list:${container.markerIndent}:${container.indent}:` +
+      (container.orderedStart === null ? "bullet" : "ordered")).join("/");
   let state = cache.get(key);
   if (!state || state.index > index) {
     state = { index: 0, paragraphOpen: false };
@@ -341,7 +359,9 @@ function paragraphOpenBefore(lines, index, containers, paragraphCache) {
     if (startsNewListItem(lines[previous], containers)) {
       state.paragraphOpen = false;
     }
-    const content = continueBlockContainers(lines[previous], containers);
+    const content = paragraphContentWithinContainers(
+      lines[previous], containers,
+    );
     if (content === null) {
       state.paragraphOpen = state.paragraphOpen &&
         lazyParagraphContinuation(lines[previous], containers);
@@ -389,6 +409,31 @@ function paragraphOpenAfter(line, paragraphOpen) {
 function continueBlockContainers(line, containers) {
   const continued = blockContainerPrefix(line, containers);
   return continued.count === containers.length ? continued.content : null;
+}
+
+function paragraphContentWithinContainers(line, containers) {
+  let remaining = line.replace(/\r$/, "");
+  for (const container of containers) {
+    if (container.type === "quote") {
+      const quote = remaining.match(/^ {0,3}>[ \t]?/);
+      if (!quote) {
+        return null;
+      }
+      remaining = remaining.slice(quote[0].length);
+      continue;
+    }
+    const marker = listMarkerPrefix(remaining);
+    if (marker?.markerIndent === container.markerIndent) {
+      remaining = remaining.slice(marker.length);
+      continue;
+    }
+    const stripped = stripIndent(remaining, container.indent);
+    if (stripped === null) {
+      return null;
+    }
+    remaining = stripped;
+  }
+  return remaining;
 }
 
 function blockContainerPrefix(line, containers) {

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -213,7 +213,8 @@ function parseBlockContainers(line, orderedListCanInterrupt = null) {
     }
     const list = listMarkerPrefix(remaining);
     if (list) {
-      if (list.orderedStart !== null && list.orderedStart !== 1 &&
+      if ((list.empty ||
+           (list.orderedStart !== null && list.orderedStart !== 1)) &&
           orderedListCanInterrupt && !orderedListCanInterrupt(containers)) {
         return { content: remaining, containers };
       }
@@ -267,10 +268,20 @@ function listMarkerPrefix(value) {
   }
 
   let index = marker[0].length;
+  const markerColumn = indentationWidth(value.slice(0, index));
+  const empty = !value.slice(index).trim();
+  if (index === value.length) {
+    return {
+      length: index,
+      indent: markerColumn + 1,
+      markerIndent: marker[1].length,
+      orderedStart: marker[2] === undefined ? null : Number(marker[2]),
+      empty: true,
+    };
+  }
   if (value[index] !== " " && value[index] !== "\t") {
     return null;
   }
-  const markerColumn = indentationWidth(value.slice(0, index));
   const firstPaddingEnd = index + 1;
   const firstPaddingColumn = value[index] === "\t"
     ? markerColumn + 4 - (markerColumn % 4)
@@ -284,6 +295,7 @@ function listMarkerPrefix(value) {
         indent: firstPaddingColumn,
         markerIndent: marker[1].length,
         orderedStart: marker[2] === undefined ? null : Number(marker[2]),
+        empty,
       };
     }
     index++;
@@ -293,6 +305,7 @@ function listMarkerPrefix(value) {
     indent: column,
     markerIndent: marker[1].length,
     orderedStart: marker[2] === undefined ? null : Number(marker[2]),
+    empty,
   };
 }
 
@@ -352,6 +365,9 @@ function paragraphOpenAfter(line, paragraphOpen) {
   }
   const list = listMarkerPrefix(value);
   if (list) {
+    if (list.empty && value.trim() !== "-") {
+      return paragraphOpen;
+    }
     return paragraphOpen && list.orderedStart !== null && list.orderedStart !== 1;
   }
   if (/^(?: {4}|\t)/.test(value)) {

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -526,13 +526,12 @@ function indentationWidth(value) {
 function stripIndent(line, width) {
   let column = 0;
   let index = 0;
-  while (index < line.length && column < width) {
+  while (index < line.length &&
+         (line[index] === " " || line[index] === "\t")) {
     if (line[index] === " ") {
       column++;
-    } else if (line[index] === "\t") {
-      column += 4 - (column % 4);
     } else {
-      return null;
+      column += 4 - (column % 4);
     }
     index++;
   }

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -614,7 +614,7 @@ function withoutFencedCode(contents) {
     if (fence) {
       const content = continueBlockContainers(line, fence.containers);
       if (content !== null) {
-        const closing = content.match(/^[ \t]{0,3}(`+|~+)[ \t]*$/)?.[1] || "";
+        const closing = content.match(/^ {0,3}(`+|~+)[ \t]*$/)?.[1] || "";
         if (closing[0] === fence.character && closing.length >= fence.length) {
           fence = null;
         }
@@ -705,7 +705,7 @@ function withoutFencedCode(contents) {
 }
 
 function fencedCodeOpening(content) {
-  const opening = content.match(/^[ \t]{0,3}(`{3,}|~{3,})(.*)$/);
+  const opening = content.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
   if (!opening || (opening[1][0] === "`" && opening[2].includes("`"))) {
     return null;
   }

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -61,7 +61,8 @@ export function markdownTargets(contents) {
 function referenceDefinitionAt(lines, index, checkParagraphInterruption = true) {
   const parsedLine = parseBlockContainers(lines[index]);
   if (checkParagraphInterruption &&
-      orderedListInterruptsParagraph(lines, index, parsedLine.containers)) {
+      (orderedListInterruptsParagraph(lines, index, parsedLine.containers) ||
+       paragraphOpenBefore(lines, index, parsedLine.containers))) {
     return null;
   }
   const match = parsedLine.content.match(
@@ -287,7 +288,7 @@ function paragraphOpenAfter(line, paragraphOpen) {
     return paragraphOpen;
   }
   if (/^ {0,3}(?:#{1,6}(?:[ \t]+|$)|>|`{3,}|~{3,})/.test(value) ||
-      /^ {0,3}(?:(?:\*[ \t]*){3,}|(?:_[ \t]*){3,}|(?:-[ \t]*){3,}|=+[ \t]*)$/.test(value)) {
+      /^ {0,3}(?:(?:\*[ \t]*){3,}|(?:_[ \t]*){3,}|(?:-[ \t]*)+|=+[ \t]*)$/.test(value)) {
     return false;
   }
   if (/^ {0,3}\[(?!\^)(?:\\.|[^\]\\\n])+\]:/.test(value)) {

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -197,16 +197,36 @@ function parseBlockContainers(line) {
       containers.push({ type: "quote" });
       continue;
     }
-    const list = remaining.match(
-      /^[ \t]{0,3}(?:[-+*]|\d{1,9}[.)])(?: {1,4}(?![ \t])|\t)/,
-    );
+    const list = listMarkerPrefix(remaining);
     if (list) {
-      remaining = remaining.slice(list[0].length);
-      containers.push({ type: "list", indent: indentationWidth(list[0]) });
+      remaining = remaining.slice(list.length);
+      containers.push({ type: "list", indent: list.indent });
       continue;
     }
     return { content: remaining, containers };
   }
+}
+
+function listMarkerPrefix(value) {
+  const marker = value.match(/^( {0,3})(?:[-+*]|\d{1,9}[.)])/);
+  if (!marker) {
+    return null;
+  }
+
+  let index = marker[0].length;
+  if (value[index] !== " " && value[index] !== "\t") {
+    return null;
+  }
+  const markerColumn = indentationWidth(value.slice(0, index));
+  let column = markerColumn;
+  while (value[index] === " " || value[index] === "\t") {
+    column = value[index] === "\t" ? column + 4 - (column % 4) : column + 1;
+    if (column - markerColumn > 4) {
+      return null;
+    }
+    index++;
+  }
+  return { length: index, indent: column };
 }
 
 function continueBlockContainers(line, containers) {

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -228,6 +228,28 @@ function continueBlockContainers(line, containers) {
   return remaining;
 }
 
+function blankWithinBlockContainers(line, containers) {
+  let remaining = line.replace(/\r$/, "");
+  for (const container of containers) {
+    if (container.type === "quote") {
+      const quote = remaining.match(/^[ \t]{0,3}>[ \t]?/);
+      if (!quote) {
+        return false;
+      }
+      remaining = remaining.slice(quote[0].length);
+      continue;
+    }
+    if (!remaining.trim()) {
+      return true;
+    }
+    remaining = stripIndent(remaining, container.indent);
+    if (remaining === null) {
+      return false;
+    }
+  }
+  return !remaining.trim();
+}
+
 function indentationWidth(value) {
   let column = 0;
   for (const character of value) {
@@ -268,7 +290,7 @@ function withoutFencedCode(contents) {
         }
         return "";
       }
-      if (!line.trim() && !fence.containers.some(({ type }) => type === "quote")) {
+      if (blankWithinBlockContainers(line, fence.containers)) {
         return "";
       }
       fence = null;

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -222,9 +222,9 @@ function parseBlockContainers(line, orderedListCanInterrupt = null) {
   let remaining = line.replace(/\r$/, "");
   const containers = [];
   while (true) {
-    const quote = remaining.match(/^ {0,3}>[ \t]?/);
-    if (quote) {
-      remaining = remaining.slice(quote[0].length);
+    const quoteContent = stripBlockQuoteMarker(remaining);
+    if (quoteContent !== null) {
+      remaining = quoteContent;
       containers.push({ type: "quote" });
       continue;
     }
@@ -247,6 +247,25 @@ function parseBlockContainers(line, orderedListCanInterrupt = null) {
     }
     return { content: remaining, containers };
   }
+}
+
+function stripBlockQuoteMarker(line) {
+  const marker = line.match(/^( {0,3})>/);
+  if (!marker) {
+    return null;
+  }
+  let index = marker[0].length;
+  let column = marker[1].length + 1;
+  const whitespaceStartColumn = column;
+  while (line[index] === " " || line[index] === "\t") {
+    column = line[index] === "\t"
+      ? column + 4 - (column % 4)
+      : column + 1;
+    index++;
+  }
+  const whitespaceWidth = column - whitespaceStartColumn;
+  const contentIndent = whitespaceWidth > 0 ? whitespaceWidth - 1 : 0;
+  return `${" ".repeat(contentIndent)}${line.slice(index)}`;
 }
 
 function parseContinuedBlockContainers(
@@ -415,11 +434,11 @@ function paragraphContentWithinContainers(line, containers) {
   let remaining = line.replace(/\r$/, "");
   for (const container of containers) {
     if (container.type === "quote") {
-      const quote = remaining.match(/^ {0,3}>[ \t]?/);
-      if (!quote) {
+      const quoteContent = stripBlockQuoteMarker(remaining);
+      if (quoteContent === null) {
         return null;
       }
-      remaining = remaining.slice(quote[0].length);
+      remaining = quoteContent;
       continue;
     }
     const marker = listMarkerPrefix(remaining);
@@ -441,11 +460,11 @@ function blockContainerPrefix(line, containers) {
   let count = 0;
   for (const container of containers) {
     if (container.type === "quote") {
-      const quote = remaining.match(/^ {0,3}>[ \t]?/);
-      if (!quote) {
+      const quoteContent = stripBlockQuoteMarker(remaining);
+      if (quoteContent === null) {
         break;
       }
-      remaining = remaining.slice(quote[0].length);
+      remaining = quoteContent;
     } else {
       const stripped = stripIndent(remaining, container.indent);
       if (stripped === null) {
@@ -465,11 +484,11 @@ function startsNewListItem(line, containers) {
   let remaining = line.replace(/\r$/, "");
   for (const container of containers) {
     if (container.type === "quote") {
-      const quote = remaining.match(/^ {0,3}>[ \t]?/);
-      if (!quote) {
+      const quoteContent = stripBlockQuoteMarker(remaining);
+      if (quoteContent === null) {
         return false;
       }
-      remaining = remaining.slice(quote[0].length);
+      remaining = quoteContent;
       continue;
     }
     const marker = listMarkerPrefix(remaining);
@@ -495,11 +514,11 @@ function blankWithinBlockContainers(line, containers) {
   let remaining = line.replace(/\r$/, "");
   for (const container of containers) {
     if (container.type === "quote") {
-      const quote = remaining.match(/^ {0,3}>[ \t]?/);
-      if (!quote) {
+      const quoteContent = stripBlockQuoteMarker(remaining);
+      if (quoteContent === null) {
         return false;
       }
-      remaining = remaining.slice(quote[0].length);
+      remaining = quoteContent;
       continue;
     }
     if (!remaining.trim()) {

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -240,7 +240,9 @@ function blankWithinBlockContainers(line, containers) {
       continue;
     }
     if (!remaining.trim()) {
-      return true;
+      // A blank line may omit list indentation, but any inner quote
+      // containers must still be checked below.
+      continue;
     }
     remaining = stripIndent(remaining, container.indent);
     if (remaining === null) {

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -221,6 +221,7 @@ function parseBlockContainers(line, orderedListCanInterrupt = null) {
       containers.push({
         type: "list",
         indent: list.indent,
+        markerIndent: list.markerIndent,
         orderedStart: list.orderedStart,
       });
       continue;
@@ -281,6 +282,7 @@ function listMarkerPrefix(value) {
       return {
         length: firstPaddingEnd,
         indent: firstPaddingColumn,
+        markerIndent: marker[1].length,
         orderedStart: marker[2] === undefined ? null : Number(marker[2]),
       };
     }
@@ -289,6 +291,7 @@ function listMarkerPrefix(value) {
   return {
     length: index,
     indent: column,
+    markerIndent: marker[1].length,
     orderedStart: marker[2] === undefined ? null : Number(marker[2]),
   };
 }
@@ -319,6 +322,9 @@ function paragraphOpenBefore(lines, index, containers, paragraphCache) {
   while (state.index < index) {
     const previous = state.index;
     state.index++;
+    if (startsNewListItem(lines[previous], containers)) {
+      state.paragraphOpen = false;
+    }
     const content = continueBlockContainers(lines[previous], containers);
     if (content === null) {
       state.paragraphOpen = state.paragraphOpen &&
@@ -336,7 +342,7 @@ function paragraphOpenBefore(lines, index, containers, paragraphCache) {
     }
     state.paragraphOpen = nextParagraphOpen;
   }
-  return state.paragraphOpen;
+  return !startsNewListItem(lines[index], containers) && state.paragraphOpen;
 }
 
 function paragraphOpenAfter(line, paragraphOpen) {
@@ -386,6 +392,33 @@ function blockContainerPrefix(line, containers) {
     count++;
   }
   return { content: remaining, count };
+}
+
+function startsNewListItem(line, containers) {
+  if (line === undefined) {
+    return false;
+  }
+  let remaining = line.replace(/\r$/, "");
+  for (const container of containers) {
+    if (container.type === "quote") {
+      const quote = remaining.match(/^ {0,3}>[ \t]?/);
+      if (!quote) {
+        return false;
+      }
+      remaining = remaining.slice(quote[0].length);
+      continue;
+    }
+    const marker = listMarkerPrefix(remaining);
+    if (marker?.markerIndent === container.markerIndent) {
+      return true;
+    }
+    const stripped = stripIndent(remaining, container.indent);
+    if (stripped === null) {
+      return false;
+    }
+    remaining = stripped;
+  }
+  return false;
 }
 
 function lazyParagraphContinuation(line, containers) {
@@ -502,9 +535,10 @@ function withoutFencedCode(contents) {
       : parseBlockContainers(line, orderedListCanInterrupt);
     activeContainers = parsed.containers;
     if (stripIndent(parsed.content, 4) !== null &&
-        !paragraphOpenBefore(
-          output, output.length, parsed.containers, paragraphCache,
-        )) {
+        (startsNewListItem(line, parsed.containers) ||
+         !paragraphOpenBefore(
+           output, output.length, parsed.containers, paragraphCache,
+         ))) {
       output.push("");
       continue;
     }

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -127,7 +127,9 @@ function stripBlockContainers(line) {
       remaining = remaining.slice(quote[0].length);
       continue;
     }
-    const list = remaining.match(/^[ \t]{0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+/);
+    const list = remaining.match(
+      /^[ \t]{0,3}(?:[-+*]|\d{1,9}[.)])(?: {1,4}(?![ \t])|\t)/,
+    );
     if (list) {
       remaining = remaining.slice(list[0].length);
       continue;
@@ -143,7 +145,7 @@ function isExternal(target) {
 function withoutFencedCode(contents) {
   let fence = "";
   return contents.split("\n").map((line) => {
-    const marker = line.match(/^\s*(```+|~~~+)/)?.[1] || "";
+    const marker = stripBlockContainers(line).match(/^\s*(```+|~~~+)/)?.[1] || "";
     if (marker && !fence) {
       fence = marker[0];
       return "";

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -186,7 +186,9 @@ function completeReferenceTitle(initial, lines, nextIndex, containers) {
     if (!unterminatedReferenceTitle(value)) {
       return { valid: false, consumed: 0 };
     }
-    const continuation = referenceContinuation(lines, nextIndex + consumed, containers);
+    const continuation = referenceTitleContinuation(
+      lines, nextIndex + consumed, containers,
+    );
     if (continuation === null || !continuation.trim()) {
       return { valid: false, consumed: 0 };
     }
@@ -216,6 +218,14 @@ function referenceContinuation(lines, index, containers) {
   }
   const continuation = continueBlockContainers(lines[index], containers);
   return continuation?.match(/^[ \t]{0,3}(\S.*)$/)?.[1] || null;
+}
+
+function referenceTitleContinuation(lines, index, containers) {
+  if (index >= lines.length) {
+    return null;
+  }
+  const continuation = continueBlockContainers(lines[index], containers);
+  return continuation?.match(/^[ \t]*(\S.*)$/)?.[1] || null;
 }
 
 function parseBlockContainers(line, orderedListCanInterrupt = null) {
@@ -594,9 +604,13 @@ function withoutFencedCode(contents) {
   let fence = null;
   let htmlBlock = null;
   let activeContainers = [];
+  let referenceContinuationThrough = -1;
   const output = [];
   const paragraphCache = new Map();
-  for (const line of contents.split("\n")) {
+  const definitionParagraphCache = new Map();
+  const lines = contents.split("\n");
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
     if (fence) {
       const content = continueBlockContainers(line, fence.containers);
       if (content !== null) {
@@ -630,6 +644,11 @@ function withoutFencedCode(contents) {
       htmlBlock = null;
     }
 
+    if (index <= referenceContinuationThrough) {
+      output.push(line);
+      continue;
+    }
+
     const orderedListCanInterrupt = (containers) =>
       !paragraphOpenBefore(
         output, output.length, containers, paragraphCache,
@@ -645,6 +664,12 @@ function withoutFencedCode(contents) {
       )
       : parseBlockContainers(line, orderedListCanInterrupt);
     activeContainers = parsed.containers;
+    const definition = referenceDefinitionAt(
+      lines, index, true, definitionParagraphCache, parsed,
+    );
+    if (definition?.consumed) {
+      referenceContinuationThrough = index + definition.consumed;
+    }
     if (stripIndent(parsed.content, 4) !== null &&
         (startsNewListItem(line, parsed.containers) ||
          !paragraphOpenBefore(

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -102,6 +102,25 @@ test("keeps a list fence open across an unindented blank line", () => {
   ].join("\n")), []);
 });
 
+test("preserves list context after masking block content", () => {
+  assert.deepEqual(markdownTargets([
+    "10. ```",
+    "    code",
+    "    ```",
+    "    [missing]: docs/missing.md",
+  ].join("\n")), ["docs/missing.md"]);
+  assert.deepEqual(markdownTargets([
+    "> 10. <script>",
+    ">     const example = true;",
+    ">     </script>",
+    ">     [nested]: docs/nested.md",
+  ].join("\n")), ["docs/nested.md"]);
+  assert.deepEqual(markdownTargets([
+    "10.     indented code",
+    "    [after-code]: docs/after-code.md",
+  ].join("\n")), ["docs/after-code.md"]);
+});
+
 test("does not mask fences from ordered markers inside paragraphs", () => {
   assert.deepEqual(markdownTargets([
     "Paragraph",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -121,6 +121,16 @@ test("preserves list context after masking block content", () => {
   ].join("\n")), ["docs/after-code.md"]);
 });
 
+test("preserves paragraph interruption after masking list blocks", () => {
+  assert.deepEqual(markdownTargets([
+    "Paragraph",
+    "1. ```",
+    "   code",
+    "   ```",
+    "[after]: docs/missing.md",
+  ].join("\n")), ["docs/missing.md"]);
+});
+
 test("does not mask fences from ordered markers inside paragraphs", () => {
   assert.deepEqual(markdownTargets([
     "Paragraph",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -196,6 +196,17 @@ test("respects ordered-list paragraph interruption rules", () => {
   ]);
 });
 
+test("preserves outer list context for nested interruptions", () => {
+  assert.deepEqual(markdownTargets([
+    "- Outer paragraph",
+    "  2. [continued]: docs/not-a-definition.md",
+  ].join("\n")), []);
+  assert.deepEqual(markdownTargets([
+    "- Outer paragraph",
+    "  1. [nested]: docs/nested.md",
+  ].join("\n")), ["docs/nested.md"]);
+});
+
 test("does not let reference definitions interrupt paragraphs", () => {
   assert.deepEqual(markdownTargets([
     "Top-level paragraph",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -313,6 +313,26 @@ test("recognizes GFM table boundaries before definitions", () => {
     "docs/quoted-table.md",
     "docs/listed-table.md",
   ]);
+  assert.deepEqual(markdownTargets([
+    "A | B",
+    "| --- |",
+    "2. ~~~",
+    "   [active](docs/active.md)",
+    "   ~~~",
+  ].join("\n")), ["docs/active.md"]);
+  assert.deepEqual(markdownTargets([
+    "Earlier paragraph line",
+    "A | B",
+    "| --- | --- |",
+    "2. ~~~",
+    "   [multiline](docs/multiline.md)",
+    "   ~~~",
+  ].join("\n")), ["docs/multiline.md"]);
+  assert.deepEqual(markdownTargets([
+    "| A \\| B |",
+    "| --- |",
+    "[escaped]: docs/escaped-pipe.md",
+  ].join("\n")), ["docs/escaped-pipe.md"]);
 });
 
 test("keeps invalid backtick fence candidates in paragraphs", () => {

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -223,6 +223,16 @@ test("does not let reference definitions interrupt paragraphs", () => {
   ]);
 });
 
+test("keeps invalid backtick fence candidates in paragraphs", () => {
+  assert.deepEqual(markdownTargets([
+    "Paragraph",
+    "``` foo ` bar",
+    "[continued]: docs/not-a-definition.md",
+    "",
+    "[after-blank]: docs/after-blank.md",
+  ].join("\n")), ["docs/after-blank.md"]);
+});
+
 test("preserves lazy block-quote paragraph continuations", () => {
   assert.deepEqual(markdownTargets([
     "> Quoted paragraph",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -108,6 +108,28 @@ test("lets type-6 HTML blocks interrupt paragraphs", () => {
   ].join("\n")), ["docs/visible.md"]);
 });
 
+test("recognizes type-7 HTML blocks only outside paragraphs", () => {
+  assert.deepEqual(markdownTargets([
+    '<custom-tag data-state = "open" disabled>',
+    "# raw HTML",
+    "[hidden-open]: docs/not-open.md",
+    "",
+    "</custom-tag   >",
+    "[hidden-close]: docs/not-close.md",
+    "",
+    "[visible]: docs/visible.md",
+  ].join("\n")), ["docs/visible.md"]);
+  assert.deepEqual(markdownTargets([
+    "Paragraph",
+    "<span>",
+    "[active](docs/active.md)",
+  ].join("\n")), ["docs/active.md"]);
+  assert.deepEqual(markdownTargets([
+    '<span bad*="value">',
+    "[active](docs/active.md)",
+  ].join("\n")), ["docs/active.md"]);
+});
+
 test("ignores fenced code nested in block containers", () => {
   assert.deepEqual(markdownTargets([
     "> ```markdown",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -283,6 +283,31 @@ test("keeps indented list continuations visible", () => {
   ].join("\n")), ["docs/inline.md", "docs/second.md"]);
 });
 
+test("recognizes empty list items without breaking Setext headings", () => {
+  assert.deepEqual(markdownTargets([
+    "-",
+    "    [unordered](docs/unordered.md)",
+    "1.",
+    "    [ordered](docs/ordered.md)",
+    "> -",
+    ">     [quoted](docs/quoted.md)",
+  ].join("\n")), [
+    "docs/unordered.md",
+    "docs/ordered.md",
+    "docs/quoted.md",
+  ]);
+  assert.deepEqual(markdownTargets([
+    "Heading",
+    "-",
+    "    [code](docs/not-visible.md)",
+  ].join("\n")), []);
+  assert.deepEqual(markdownTargets([
+    "Paragraph",
+    "+",
+    "    [continuation](docs/continuation.md)",
+  ].join("\n")), ["docs/continuation.md"]);
+});
+
 test("resets paragraph state between sibling list items", () => {
   assert.deepEqual(markdownTargets([
     "- First item",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -414,6 +414,15 @@ test("extracts references with multiline titles", () => {
   ]);
 });
 
+test("scans multiline definitions with active list containers", () => {
+  assert.deepEqual(markdownTargets([
+    "-",
+    "    [first]: docs/first.md \"A long",
+    "    title\"",
+    "    [second]: docs/second.md",
+  ].join("\n")), ["docs/first.md", "docs/second.md"]);
+});
+
 test("reports a missing local reference target", () => {
   const root = mkdtempSync(join(tmpdir(), "error-tracer-doc-links-"));
   mkdirSync(join(root, "docs"));

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -12,8 +12,10 @@ test("extracts inline and reference-definition targets", () => {
   const contents = [
     "[inline](docs/inline.md)",
     "[guide][guide-ref]",
+    "",
     "[guide-ref]: <docs/guide.md> \"Guide\"",
     "![asset][asset-ref]",
+    "",
     "[asset-ref]: images/example.png 'Example'",
   ].join("\n");
 
@@ -153,6 +155,30 @@ test("respects ordered-list paragraph interruption rules", () => {
     "docs/after-blank.md",
     "docs/nested.md",
   ]);
+});
+
+test("does not let reference definitions interrupt paragraphs", () => {
+  assert.deepEqual(markdownTargets([
+    "Top-level paragraph",
+    "[top-level]: docs/not-top-level.md",
+    "",
+    "[after-blank]: docs/after-blank.md",
+    "> Quoted paragraph",
+    "> [quoted]: docs/not-quoted.md",
+    ">",
+    "> [quoted-after-blank]: docs/quoted.md",
+  ].join("\n")), [
+    "docs/after-blank.md",
+    "docs/quoted.md",
+  ]);
+});
+
+test("recognizes short hyphen setext underlines", () => {
+  assert.deepEqual(markdownTargets([
+    "Heading",
+    "-",
+    "2. [after-heading]: docs/after-heading.md",
+  ].join("\n")), ["docs/after-heading.md"]);
 });
 
 test("treats a tab-indented block quote as code", () => {

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -380,6 +380,20 @@ test("keeps noninterrupting list-like code in paragraphs visible", () => {
   ].join("\n")), ["docs/unordered.md", "docs/ordered.md"]);
 });
 
+test("keeps paragraphs open after noninterrupting list-like code", () => {
+  assert.deepEqual(markdownTargets([
+    "Paragraph",
+    "-     unordered code",
+    "[unordered]: docs/not-unordered.md",
+    "Paragraph",
+    "1.     ordered code",
+    "[ordered]: docs/not-ordered.md",
+    "> Paragraph",
+    "> -     quoted code",
+    "> [quoted]: docs/not-quoted.md",
+  ].join("\n")), []);
+});
+
 test("keeps indented list continuations visible", () => {
   assert.deepEqual(markdownTargets([
     "- List item",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -256,6 +256,11 @@ test("ignores links in four-column indented code", () => {
     ].join("\n"),
     ">     [quoted](docs/quoted-missing.md)",
     "-     [listed](docs/listed-missing.md)",
+    [
+      "- Previous item",
+      "  continuation",
+      "-     [sibling-code](docs/sibling-code-missing.md)",
+    ].join("\n"),
     "\t[tabbed](docs/tabbed-missing.md)",
   ]) {
     assert.deepEqual(markdownTargets(contents), []);
@@ -276,6 +281,25 @@ test("keeps indented list continuations visible", () => {
     "  continued",
     "  [second](docs/second.md)",
   ].join("\n")), ["docs/inline.md", "docs/second.md"]);
+});
+
+test("resets paragraph state between sibling list items", () => {
+  assert.deepEqual(markdownTargets([
+    "- First item",
+    "  continuation",
+    "- [second]: docs/second.md",
+    "> - Quoted item",
+    ">   continuation",
+    "> - [quoted]: docs/quoted.md",
+    "- Outer item",
+    "  - Inner item",
+    "    continuation",
+    "  - [nested]: docs/nested.md",
+  ].join("\n")), [
+    "docs/second.md",
+    "docs/quoted.md",
+    "docs/nested.md",
+  ]);
 });
 
 test("parses mixed space-and-tab list padding", () => {

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -61,6 +61,22 @@ test("preserves multiline reference titles after HTML blocks", () => {
   ].join("\n")), ["docs/missing.md"]);
 });
 
+test("ignores blank-terminated type-6 HTML blocks", () => {
+  assert.deepEqual(markdownTargets([
+    "> <div>",
+    "> # raw HTML",
+    "> [bad]: docs/not-visible.md",
+    ">",
+    "> [good]: docs/visible.md",
+  ].join("\n")), ["docs/visible.md"]);
+  assert.deepEqual(markdownTargets([
+    "- <table>",
+    "  [bad]: docs/not-visible.md",
+    "",
+    "  [good]: docs/visible.md",
+  ].join("\n")), ["docs/visible.md"]);
+});
+
 test("ignores fenced code nested in block containers", () => {
   assert.deepEqual(markdownTargets([
     "> ```markdown",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -250,6 +250,13 @@ test("treats a tab-indented block quote as code", () => {
   ), []);
 });
 
+test("preserves tab columns after block-quote markers", () => {
+  assert.deepEqual(markdownTargets([
+    ">\t  [code]: docs/not-visible.md",
+    "> \t[visible]: docs/visible.md",
+  ].join("\n")), ["docs/visible.md"]);
+});
+
 test("ignores indented code after list markers", () => {
   assert.deepEqual(markdownTargets([
     "-     [unordered]: docs/unordered-missing.md",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -40,6 +40,25 @@ test("ignores GitHub footnote definitions", () => {
   ].join("\n")), []);
 });
 
+test("ignores prose that resembles a reference definition", () => {
+  assert.deepEqual(markdownTargets([
+    "[status]: Not yet available",
+    "[owner]: Documentation team",
+  ].join("\n")), []);
+});
+
+test("extracts definitions nested in block containers", () => {
+  assert.deepEqual(markdownTargets([
+    "> [quoted]: docs/quoted.md",
+    "- [listed]: <docs/listed.md> \"Listed guide\"",
+    "1. > [nested]: docs/nested.md 'Nested guide'",
+  ].join("\n")), [
+    "docs/quoted.md",
+    "docs/listed.md",
+    "docs/nested.md",
+  ]);
+});
+
 test("extracts reference destinations continued on the next line", () => {
   assert.deepEqual(markdownTargets([
     "[guide]:",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -143,6 +143,14 @@ test("ignores indented code after list markers", () => {
   ].join("\n")), []);
 });
 
+test("parses mixed space-and-tab list padding", () => {
+  assert.deepEqual(markdownTargets([
+    "- \t```markdown",
+    "    [missing](docs/missing.md)",
+    "    ```",
+  ].join("\n")), []);
+});
+
 test("extracts reference destinations continued on the next line", () => {
   assert.deepEqual(markdownTargets([
     "[guide]:",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -46,6 +46,41 @@ test("ignores fenced code nested in block containers", () => {
   ].join("\n")), []);
 });
 
+test("keeps longer container fences open past shorter marker runs", () => {
+  assert.deepEqual(markdownTargets([
+    "> ````markdown",
+    "> ```",
+    "> [missing]: docs/still-fenced.md",
+    "> ````",
+  ].join("\n")), []);
+});
+
+test("ends unclosed fences at their container boundary", () => {
+  assert.deepEqual(markdownTargets([
+    "> ```markdown",
+    "> quoted code",
+    "",
+    "[after-quote]: docs/after-quote.md",
+    "- ~~~markdown",
+    "  listed code",
+    "",
+    "[after-list]: docs/after-list.md",
+  ].join("\n")), [
+    "docs/after-quote.md",
+    "docs/after-list.md",
+  ]);
+});
+
+test("keeps a list fence open across an unindented blank line", () => {
+  assert.deepEqual(markdownTargets([
+    "- ```markdown",
+    "  listed code",
+    "",
+    "  [missing]: docs/still-in-list-fence.md",
+    "  ```",
+  ].join("\n")), []);
+});
+
 test("ignores GitHub footnote definitions", () => {
   assert.deepEqual(markdownTargets([
     "A statement with a footnote.[^1]",
@@ -86,9 +121,15 @@ test("extracts reference destinations continued on the next line", () => {
     "  docs/guide.md",
     "[wrapped]:",
     "   <docs/wrapped.md> \"Wrapped guide\"",
+    "10. [ordered]:",
+    "    docs/ordered.md",
+    "> 10. [nested]:",
+    ">     docs/nested-ordered.md",
   ].join("\n")), [
     "docs/guide.md",
     "docs/wrapped.md",
+    "docs/ordered.md",
+    "docs/nested-ordered.md",
   ]);
 });
 

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -234,12 +234,30 @@ test("ends an unclosed quote fence before a new quote block", () => {
   ].join("\n")), ["docs/new-quote.md"]);
 });
 
-test("ignores GitHub footnote definitions", () => {
+test("ignores GitHub footnotes while preserving block boundaries", () => {
   assert.deepEqual(markdownTargets([
     "A statement with a footnote.[^1]",
     "",
     "[^1]: This is explanatory prose, not a link destination.",
   ].join("\n")), []);
+  assert.deepEqual(markdownTargets([
+    "[^1]: explanation",
+    "[after-footnote]: docs/after-footnote.md",
+    "Paragraph",
+    "[^2]: interrupts the paragraph",
+    "[after-interruption]: docs/after-interruption.md",
+    "> [^quoted]: quoted explanation",
+    "> [quoted-after]: docs/quoted-after.md",
+  ].join("\n")), [
+    "docs/after-footnote.md",
+    "docs/after-interruption.md",
+    "docs/quoted-after.md",
+  ]);
+  assert.deepEqual(markdownTargets([
+    "[^multiline]:",
+    "    indented continuation",
+    "[after-multiline]: docs/after-multiline.md",
+  ].join("\n")), ["docs/after-multiline.md"]);
 });
 
 test("ignores prose that resembles a reference definition", () => {

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -59,6 +59,27 @@ test("preserves multiline reference titles after HTML blocks", () => {
     "[missing]: docs/missing.md \"long",
     "    title\"",
   ].join("\n")), ["docs/missing.md"]);
+  assert.deepEqual(markdownTargets([
+    "<script>",
+    "raw script",
+    "</script>",
+    "[script]: docs/script.md \"long",
+    "    title\"",
+    "<!--",
+    "raw comment",
+    "-->",
+    "[comment]: docs/comment.md \"long",
+    "    title\"",
+    "<?processing",
+    "raw instruction",
+    "?>",
+    "[instruction]: docs/instruction.md \"long",
+    "    title\"",
+  ].join("\n")), [
+    "docs/script.md",
+    "docs/comment.md",
+    "docs/instruction.md",
+  ]);
 });
 
 test("ignores blank-terminated type-6 HTML blocks", () => {

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -297,6 +297,24 @@ test("does not let reference definitions interrupt paragraphs", () => {
   ]);
 });
 
+test("recognizes GFM table boundaries before definitions", () => {
+  assert.deepEqual(markdownTargets([
+    "| A | B |",
+    "| :--- | ---: |",
+    "[table]: docs/table.md",
+    "> | A |",
+    "> | --- |",
+    "> [quoted]: docs/quoted-table.md",
+    "- | A |",
+    "  | --- |",
+    "  [listed]: docs/listed-table.md",
+  ].join("\n")), [
+    "docs/table.md",
+    "docs/quoted-table.md",
+    "docs/listed-table.md",
+  ]);
+});
+
 test("keeps invalid backtick fence candidates in paragraphs", () => {
   assert.deepEqual(markdownTargets([
     "Paragraph",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -136,6 +136,31 @@ test("extracts definitions nested in block containers", () => {
   ]);
 });
 
+test("respects ordered-list paragraph interruption rules", () => {
+  assert.deepEqual(markdownTargets([
+    "Paragraph text",
+    "2. [continued]: docs/not-a-definition.md",
+    "Paragraph interrupted by one",
+    "1. [interrupting]: docs/interrupting.md",
+    "",
+    "2. [after-blank]: docs/after-blank.md",
+    "> Nested paragraph",
+    "> 3. [nested-continued]: docs/not-nested.md",
+    ">",
+    "> 3. [nested-after-blank]: docs/nested.md",
+  ].join("\n")), [
+    "docs/interrupting.md",
+    "docs/after-blank.md",
+    "docs/nested.md",
+  ]);
+});
+
+test("treats a tab-indented block quote as code", () => {
+  assert.deepEqual(markdownTargets(
+    "\t> [example]: docs/not-a-definition.md",
+  ), []);
+});
+
 test("ignores indented code after list markers", () => {
   assert.deepEqual(markdownTargets([
     "-     [unordered]: docs/unordered-missing.md",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -53,6 +53,14 @@ test("ignores HTML blocks and resumes after their terminators", () => {
   ]);
 });
 
+test("preserves multiline reference titles after HTML blocks", () => {
+  assert.deepEqual(markdownTargets([
+    "<script></script>",
+    "[missing]: docs/missing.md \"long",
+    "    title\"",
+  ].join("\n")), ["docs/missing.md"]);
+});
+
 test("ignores fenced code nested in block containers", () => {
   assert.deepEqual(markdownTargets([
     "> ```markdown",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -34,6 +34,25 @@ test("ignores reference definitions in fenced code", () => {
   ].join("\n")), []);
 });
 
+test("ignores HTML blocks and resumes after their terminators", () => {
+  assert.deepEqual(markdownTargets([
+    "<script></script>",
+    "[after-inline]: docs/after-inline.md",
+    "<style>",
+    "[inside-style]: docs/not-style.md",
+    "</style>",
+    "[after-style]: docs/after-style.md",
+    "<!--",
+    "[inside-comment]: docs/not-comment.md",
+    "-->",
+    "[after-comment]: docs/after-comment.md",
+  ].join("\n")), [
+    "docs/after-inline.md",
+    "docs/after-style.md",
+    "docs/after-comment.md",
+  ]);
+});
+
 test("ignores fenced code nested in block containers", () => {
   assert.deepEqual(markdownTargets([
     "> ```markdown",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -233,6 +233,20 @@ test("keeps invalid backtick fence candidates in paragraphs", () => {
   ].join("\n")), ["docs/after-blank.md"]);
 });
 
+test("measures fence indentation in visual columns", () => {
+  assert.deepEqual(markdownTargets([
+    "Paragraph",
+    "\t```",
+    "[visible](docs/visible.md)",
+  ].join("\n")), ["docs/visible.md"]);
+  assert.deepEqual(markdownTargets([
+    "```",
+    "\t```",
+    "[hidden](docs/not-visible.md)",
+    "```",
+  ].join("\n")), []);
+});
+
 test("preserves lazy block-quote paragraph continuations", () => {
   assert.deepEqual(markdownTargets([
     "> Quoted paragraph",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -98,6 +98,16 @@ test("ignores blank-terminated type-6 HTML blocks", () => {
   ].join("\n")), ["docs/visible.md"]);
 });
 
+test("lets type-6 HTML blocks interrupt paragraphs", () => {
+  assert.deepEqual(markdownTargets([
+    "Paragraph",
+    "<div>",
+    "[hidden](docs/not-visible.md)",
+    "",
+    "[visible]: docs/visible.md",
+  ].join("\n")), ["docs/visible.md"]);
+});
+
 test("ignores fenced code nested in block containers", () => {
   assert.deepEqual(markdownTargets([
     "> ```markdown",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -133,6 +133,25 @@ test("extracts reference destinations continued on the next line", () => {
   ]);
 });
 
+test("extracts references with multiline titles", () => {
+  assert.deepEqual(markdownTargets([
+    "[quoted]: docs/quoted.md \"A long",
+    "title\"",
+    "[parenthesized]: docs/parenthesized.md (Another",
+    "title)",
+    "[next-line]: docs/next-line.md",
+    "  'A title",
+    "  on following lines'",
+    "10. [ordered]: docs/ordered-title.md \"A list",
+    "    title\"",
+  ].join("\n")), [
+    "docs/quoted.md",
+    "docs/parenthesized.md",
+    "docs/next-line.md",
+    "docs/ordered-title.md",
+  ]);
+});
+
 test("reports a missing local reference target", () => {
   const root = mkdtempSync(join(tmpdir(), "error-tracer-doc-links-"));
   mkdirSync(join(root, "docs"));

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -374,6 +374,12 @@ test("parses mixed space-and-tab list padding", () => {
     "- \t```markdown",
     "    [missing](docs/missing.md)",
     "    ```",
+    "> -\t```markdown",
+    ">   [quoted](docs/quoted-missing.md)",
+    ">   ```",
+    "- -\t```markdown",
+    "    [nested](docs/nested-missing.md)",
+    "    ```",
   ].join("\n")), []);
 });
 

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -91,6 +91,15 @@ test("keeps a mixed-container fence open across a quote-only blank", () => {
   ].join("\n")), []);
 });
 
+test("ends an inner quote fence after an unmarked list blank", () => {
+  assert.deepEqual(markdownTargets([
+    "- > ```markdown",
+    "  > fenced code",
+    "",
+    "  > [new-quote]: docs/new-quote.md",
+  ].join("\n")), ["docs/new-quote.md"]);
+});
+
 test("ends an unclosed quote fence before a new quote block", () => {
   assert.deepEqual(markdownTargets([
     "> ```markdown",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -102,6 +102,26 @@ test("keeps a list fence open across an unindented blank line", () => {
   ].join("\n")), []);
 });
 
+test("does not mask fences from ordered markers inside paragraphs", () => {
+  assert.deepEqual(markdownTargets([
+    "Paragraph",
+    "2. ~~~markdown",
+    "   [top-level](docs/top-level.md)",
+    "   ~~~",
+    "",
+    "2. ~~~markdown",
+    "   [masked](docs/not-visible.md)",
+    "   ~~~",
+    "> Quoted paragraph",
+    "> 3. ~~~markdown",
+    ">    [quoted](docs/quoted.md)",
+    ">    ~~~",
+  ].join("\n")), [
+    "docs/top-level.md",
+    "docs/quoted.md",
+  ]);
+});
+
 test("keeps a mixed-container fence open across a quote-only blank", () => {
   assert.deepEqual(markdownTargets([
     "> - ```markdown",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -81,6 +81,25 @@ test("keeps a list fence open across an unindented blank line", () => {
   ].join("\n")), []);
 });
 
+test("keeps a mixed-container fence open across a quote-only blank", () => {
+  assert.deepEqual(markdownTargets([
+    "> - ```markdown",
+    ">   listed code in a quote",
+    ">",
+    ">   [missing]: docs/still-in-mixed-fence.md",
+    ">   ```",
+  ].join("\n")), []);
+});
+
+test("ends an unclosed quote fence before a new quote block", () => {
+  assert.deepEqual(markdownTargets([
+    "> ```markdown",
+    "> fenced code",
+    "",
+    "> [new-quote]: docs/new-quote.md",
+  ].join("\n")), ["docs/new-quote.md"]);
+});
+
 test("ignores GitHub footnote definitions", () => {
   assert.deepEqual(markdownTargets([
     "A statement with a footnote.[^1]",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -305,6 +305,19 @@ test("keeps indented list continuations visible", () => {
   ].join("\n")), ["docs/inline.md", "docs/second.md"]);
 });
 
+test("preserves tab columns after list indentation", () => {
+  assert.deepEqual(markdownTargets([
+    "- List item",
+    "",
+    "  \t[continuation](docs/continuation.md)",
+  ].join("\n")), ["docs/continuation.md"]);
+  assert.deepEqual(markdownTargets([
+    "- List item",
+    "",
+    "    \t[code](docs/not-visible.md)",
+  ].join("\n")), []);
+});
+
 test("recognizes empty list items without breaking Setext headings", () => {
   assert.deepEqual(markdownTargets([
     "-",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -212,6 +212,19 @@ test("does not let reference definitions interrupt paragraphs", () => {
   ]);
 });
 
+test("preserves lazy block-quote paragraph continuations", () => {
+  assert.deepEqual(markdownTargets([
+    "> Quoted paragraph",
+    "lazy continuation",
+    "> [quoted]: docs/not-a-definition.md",
+    ">",
+    "> [after-blank]: docs/quoted.md",
+    "> > Nested paragraph",
+    "> lazy nested continuation",
+    "> > [nested]: docs/not-a-nested-definition.md",
+  ].join("\n")), ["docs/quoted.md"]);
+});
+
 test("recognizes short hyphen setext underlines", () => {
   assert.deepEqual(markdownTargets([
     "Heading",
@@ -231,6 +244,38 @@ test("ignores indented code after list markers", () => {
     "-     [unordered]: docs/unordered-missing.md",
     "1.     [ordered]: docs/ordered-missing.md",
   ].join("\n")), []);
+});
+
+test("ignores links in four-column indented code", () => {
+  for (const contents of [
+    [
+      "    ```",
+      "    [inline](docs/inline-missing.md)",
+      "    [reference]: docs/reference-missing.md",
+      "    ```",
+    ].join("\n"),
+    ">     [quoted](docs/quoted-missing.md)",
+    "-     [listed](docs/listed-missing.md)",
+    "\t[tabbed](docs/tabbed-missing.md)",
+  ]) {
+    assert.deepEqual(markdownTargets(contents), []);
+  }
+});
+
+test("keeps indented lazy paragraph continuations visible", () => {
+  assert.deepEqual(markdownTargets([
+    "Paragraph",
+    "    [inline](docs/inline.md)",
+  ].join("\n")), ["docs/inline.md"]);
+});
+
+test("keeps indented list continuations visible", () => {
+  assert.deepEqual(markdownTargets([
+    "- List item",
+    "  [inline](docs/inline.md)",
+    "  continued",
+    "  [second](docs/second.md)",
+  ].join("\n")), ["docs/inline.md", "docs/second.md"]);
 });
 
 test("parses mixed space-and-tab list padding", () => {

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -32,6 +32,20 @@ test("ignores reference definitions in fenced code", () => {
   ].join("\n")), []);
 });
 
+test("ignores fenced code nested in block containers", () => {
+  assert.deepEqual(markdownTargets([
+    "> ```markdown",
+    "> [quoted]: docs/quoted-missing.md",
+    "> ```",
+    "- ~~~markdown",
+    "  [listed]: docs/listed-missing.md",
+    "  ~~~",
+    "> - ```markdown",
+    ">   [nested]: docs/nested-missing.md",
+    ">   ```",
+  ].join("\n")), []);
+});
+
 test("ignores GitHub footnote definitions", () => {
   assert.deepEqual(markdownTargets([
     "A statement with a footnote.[^1]",
@@ -57,6 +71,13 @@ test("extracts definitions nested in block containers", () => {
     "docs/listed.md",
     "docs/nested.md",
   ]);
+});
+
+test("ignores indented code after list markers", () => {
+  assert.deepEqual(markdownTargets([
+    "-     [unordered]: docs/unordered-missing.md",
+    "1.     [ordered]: docs/ordered-missing.md",
+  ].join("\n")), []);
 });
 
 test("extracts reference destinations continued on the next line", () => {

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -422,11 +422,14 @@ test("extracts references with multiline titles", () => {
     "  on following lines'",
     "10. [ordered]: docs/ordered-title.md \"A list",
     "    title\"",
+    "[indented]: docs/indented.md \"An indented",
+    "    title continuation\"",
   ].join("\n")), [
     "docs/quoted.md",
     "docs/parenthesized.md",
     "docs/next-line.md",
     "docs/ordered-title.md",
+    "docs/indented.md",
   ]);
 });
 

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -255,9 +255,20 @@ test("ignores GitHub footnotes while preserving block boundaries", () => {
   ]);
   assert.deepEqual(markdownTargets([
     "[^multiline]:",
-    "    indented continuation",
+    "    [active](docs/footnote-active.md)",
+    "    ",
+    "        [code](docs/not-footnote-code.md)",
+    "    ```markdown",
+    "    [fenced](docs/not-footnote-fence.md)",
+    "    ```",
     "[after-multiline]: docs/after-multiline.md",
-  ].join("\n")), ["docs/after-multiline.md"]);
+    "> [^quoted-multiline]:",
+    ">     [quoted-active](docs/quoted-footnote.md)",
+  ].join("\n")), [
+    "docs/footnote-active.md",
+    "docs/quoted-footnote.md",
+    "docs/after-multiline.md",
+  ]);
 });
 
 test("ignores prose that resembles a reference definition", () => {
@@ -559,6 +570,10 @@ test("recognizes empty list items without breaking Setext headings", () => {
     "+",
     "    [continuation](docs/continuation.md)",
   ].join("\n")), ["docs/continuation.md"]);
+  assert.deepEqual(markdownTargets([
+    "1.   ",
+    "    [spaced-marker](docs/spaced-marker.md)",
+  ].join("\n")), ["docs/spaced-marker.md"]);
 });
 
 test("resets paragraph state between sibling list items", () => {

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -274,6 +274,17 @@ test("keeps indented lazy paragraph continuations visible", () => {
   ].join("\n")), ["docs/inline.md"]);
 });
 
+test("keeps noninterrupting list-like code in paragraphs visible", () => {
+  assert.deepEqual(markdownTargets([
+    "Paragraph",
+    "-     [unordered](docs/unordered.md)",
+    "Another paragraph",
+    "1.     [ordered](docs/ordered.md)",
+    "",
+    "-     [code](docs/not-visible.md)",
+  ].join("\n")), ["docs/unordered.md", "docs/ordered.md"]);
+});
+
 test("keeps indented list continuations visible", () => {
   assert.deepEqual(markdownTargets([
     "- List item",

--- a/scripts/check-doc-links.test.mjs
+++ b/scripts/check-doc-links.test.mjs
@@ -343,6 +343,39 @@ test("recognizes GFM table boundaries before definitions", () => {
     "| --- |",
     "[escaped]: docs/escaped-pipe.md",
   ].join("\n")), ["docs/escaped-pipe.md"]);
+  assert.deepEqual(markdownTargets([
+    "| A |",
+    "| --- |",
+    "| body |",
+    "[after-body]: docs/after-body.md",
+    "| B |",
+    "| --- |",
+    "body without a pipe",
+    "[after-plain-body]: docs/after-plain-body.md",
+  ].join("\n")), [
+    "docs/after-body.md",
+    "docs/after-plain-body.md",
+  ]);
+  assert.deepEqual(markdownTargets([
+    "| A |",
+    "| --- |",
+    "[status]: Not yet available",
+    "another body row",
+    "[after-apparent-definition]: docs/after-apparent-definition.md",
+  ].join("\n")), ["docs/after-apparent-definition.md"]);
+  assert.deepEqual(markdownTargets([
+    "> | A |",
+    "> | --- |",
+    "> | body |",
+    "> [quoted-body]: docs/quoted-body.md",
+    "- | A |",
+    "  | --- |",
+    "  body without a pipe",
+    "  [listed-body]: docs/listed-body.md",
+  ].join("\n")), [
+    "docs/quoted-body.md",
+    "docs/listed-body.md",
+  ]);
 });
 
 test("keeps invalid backtick fence candidates in paragraphs", () => {


### PR DESCRIPTION
## Summary

- require reference definitions to contain one complete destination plus an optional syntactically valid title
- support titles on the destination line, the next line, and across multiple nonblank lines
- allow arbitrary indentation after a reference title has opened, while retaining strict initial continuation rules
- track complete definition continuation ranges before masking indented code
- reuse already stripped active-container content when paragraph scans recognize multiline definitions
- ignore prose such as `[status]: Not yet available` instead of treating its first word as a local path
- parse block-quote/list containers from visual marker padding and honor ordered-list paragraph interruption rules
- share active quote/list container state between code masking and reference-definition extraction
- use one validated fence-opener parser for both masking and paragraph-state transitions
- measure fence opener/closer indentation in visual columns, so a leading tab is four columns
- keep invalid backtick-info and over-indented fence candidates inside their surrounding paragraphs
- preserve outer list paragraphs when deciding whether nested non-`1` ordered lists may interrupt them
- preserve list/quote container scaffolding and paragraph interruption while masking fenced, HTML, and indented code blocks
- expand residual tabs at their original columns whenever quote/list containers are removed
- preserve tab-stop offsets through quote→list and list→list nesting
- distinguish tab-indented code from valid quote/list continuations and definitions
- recognize end-of-line/whitespace-only list markers while preserving Setext and paragraph-interruption semantics
- normalize empty list-item baselines to marker width plus one, regardless of trailing whitespace
- keep list-like lines whose first block is indented code inside an existing paragraph, where their links remain active
- keep those noninterrupting list-like code lines from closing the paragraph before a following reference definition
- preserve lazy block-quote and list paragraph continuations while preventing apparent definitions from interrupting them
- reset paragraph state at concrete sibling list-item boundaries, including quoted and nested lists
- mask four-column indented code, including code nested in quotes/lists, without hiding real links in paragraph or list continuations
- apply paragraph interruption rules before masking fenced-code/HTML blocks, then track their terminators and container scope
- recognize supported HTML block openers as paragraph boundaries during multiline-definition pre-scans
- feed masked historical lines into definition pre-scans while retaining original current/future continuation text
- recognize CommonMark type-6 block tags and keep their raw HTML masked until the next container-aware blank line
- normalize paragraph-cache identities by list type/baseline/indent so distinct ordered starts remain linear
- preserve valid blank fence lines plus Setext/title/continued-destination behavior
- treat GitHub footnote definitions as block boundaries without checking their prose as link targets
- retain four-column footnote continuation content while masking nested code, HTML, and fences
- preserve GFM type-6 HTML paragraph interruption semantics and keep raw-HTML links masked
- recognize complete GFM type-7 HTML tags only outside open paragraphs and mask them through their terminating blank line
- recognize GFM tables only when a single-line header and delimiter row have matching escaped-pipe-aware cell counts
- retain table state across pipe and pipe-less body rows so following block definitions remain visible

## Verification

- `bun test` (62 tests: 45 link-checker, 17 SDK)
- `bun scripts/check-doc-links.mjs` (10 Markdown files)
- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- `git diff --check`
- ordered-start stress: 10k definitions in ~0.69s
- indented-title stress: 10k definitions in ~0.25s
- tabbed-list stress: 10k continuations in ~0.85s
- tabbed-quote stress: 10k definitions in ~0.72s
- nested tabbed-fence stress: 10k examples in ~0.41s with zero false positives
- table-body stress: 10k data rows in ~0.22s

Follow-up to #64. Resolves the review findings posted after that PR had already been merged.